### PR TITLE
Fix Issue when searching not utf8 terms

### DIFF
--- a/resources/lib/youtube_plugin/kodion/abstract_provider.py
+++ b/resources/lib/youtube_plugin/kodion/abstract_provider.py
@@ -248,7 +248,11 @@ class AbstractProvider(object):
             channel_id = context.get_param('channel_id', '')
 
             query = utils.to_utf8(query)
-            self._data_cache.set('search_query', json.dumps({'query': quote(query)}))
+            try:
+                self._data_cache.set('search_query', json.dumps({'query': quote(query)}))
+            except KeyError:
+                encoded = json.dumps({'query': quote(query.encode('utf8'))})
+                self._data_cache.set('search_query', encoded)
 
             if not incognito and not channel_id:
                 try:


### PR DESCRIPTION
This PR fixes the KeyError thrown when the search term is not utf8, for example Greek or Russian or in general non latin characters. 

**The solution**: Catch the error and turn the query into a URL-safe string.

Solves [the issue 25](https://github.com/anxdpanic/plugin.video.youtube/issues/25)