### PR TITLE
Convert into binary type before re-encoding to plain ascii

### DIFF
--- a/resources/lib/youtube_registration.py
+++ b/resources/lib/youtube_registration.py
@@ -7,6 +7,7 @@
     See LICENSES/GPL-2.0-only for more information.
 """
 
+from six import PY3, binary_type
 from base64 import b64encode
 from youtube_plugin.kodion.json_store import APIKeyStore
 from youtube_plugin.kodion.impl import Context
@@ -53,7 +54,21 @@ def register_api_keys(addon_id, api_key, client_id, client_secret):
 
     jkeys = json_api['keys']['developer'].get(addon_id, {})
 
-    api_keys = {'origin': addon_id, 'main': {'system': 'JSONStore', 'key': b64encode(api_key), 'id': b64encode(client_id), 'secret': b64encode(client_secret)}}
+    if PY3:
+        api_key = b64encode(binary_type(api_key, 'utf-8')).decode('ascii')
+        client_id = b64encode(binary_type(client_id, 'utf-8')).decode('ascii')
+        client_secret = b64encode(binary_type(client_secret, 'utf-8')).decode('ascii')
+    else:
+        api_key = b64encode(api_key)
+        client_id = b64encode(client_id)
+        client_secret = b64encode(client_secret)
+
+    api_keys = {
+        'origin': addon_id, 'main': {
+            'system': 'JSONStore', 'key': api_key, 'id': client_id, 'secret': client_secret
+        }
+    }
+
     if jkeys and jkeys == api_keys:
         context.log_debug('Register API Keys: |%s| No update required' % addon_id)
     else:


### PR DESCRIPTION
On Python 3 a bytes object is required for json.dump