### PR TITLE
Specify encoding for loaded objects

### DIFF
--- a/resources/lib/youtube_plugin/kodion/utils/storage.py
+++ b/resources/lib/youtube_plugin/kodion/utils/storage.py
@@ -197,7 +197,7 @@ class Storage(object):
         def _decode(obj):
             if PY2:
                 obj = str(obj)
-            return pickle.loads(obj)
+            return pickle.loads(obj, encoding='utf-8')
 
         self._open()
         query = 'SELECT time, value FROM %s WHERE key=?' % self._table_name


### PR DESCRIPTION
### Environment
libreelec matrix
plugin.video.youtube 6.8.10+matrix.1

### Summary
plugin throws `UnicodeDecodeError` while loading search history containing Cyrillic characters


This must resolve #85 also

Please consider to merge this

Thank You!