### PR TITLE
Fix ratebypass.py

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/ratebypass/ratebypass.py
+++ b/resources/lib/youtube_plugin/youtube/helper/ratebypass/ratebypass.py
@@ -415,8 +415,8 @@ class CalculateN:
                     continue
 
             # Probably the single "b" references (references to the initial 'n'
-            # value as a MUTABLE list of characters). Append the function sent
-            # by the caller.
+            # value as a MUTABLE list of characters). Append a reference to the
+            # list sent by the caller.
             converted_array.append(initial_n_list)
 
         return converted_array


### PR DESCRIPTION
- Fixed `CalculateN.calculate_n()`.
- Simplified some of the parsing based on the fact that the function always follows the same structure and behavior.
- Replaced some regex with faster string functions.

From a couple of tests it produces the same output as the javascript original.