### PR TITLE
Expose the new `to_str` from methods.py

### DIFF
--- a/resources/lib/youtube_plugin/kodion/utils/methods.py
+++ b/resources/lib/youtube_plugin/kodion/utils/methods.py
@@ -25,7 +25,7 @@ import xbmcvfs
 
 
 __all__ = ['create_path', 'create_uri_path', 'strip_html_from_text', 'print_items', 'find_best_fit', 'to_utf8',
-           'to_unicode', 'select_stream', 'make_dirs', 'loose_version', 'find_video_id']
+           'to_str', 'to_unicode', 'select_stream', 'make_dirs', 'loose_version', 'find_video_id']
 
 try:
     xbmc.translatePath = xbmcvfs.translatePath


### PR DESCRIPTION
This is to fix a bug reported on the forums, that Kodi Leia can't find the new `kodion.utils.to_str()`.

Reference:
- https://forum.kodi.tv/showthread.php?tid=356934&pid=3057091#pid3057091
- https://paste.kodi.tv/kifequxaye.kodi