### PR TITLE
Fix throttled streaming by using a new route

### DIFF
--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_items.py
@@ -57,7 +57,7 @@ def to_play_item(context, play_item):
         inputstream_property = 'inputstream'
         if major_version < 19:
             inputstream_property += 'addon'
-
+       
         list_item.setContentLookup(False)
         list_item.setMimeType('application/xml+dash')
         list_item.setProperty(inputstream_property, 'inputstream.adaptive')
@@ -68,6 +68,15 @@ def to_play_item(context, play_item):
         if play_item.get_license_key():
             list_item.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
             list_item.setProperty('inputstream.adaptive.license_key', play_item.get_license_key())
+    else:
+        uri = play_item.get_uri()
+        if 'mime=' in uri:
+            try:
+                mimeType = uri.split('mime=', 1)[-1].split('&', 1)[0].replace('%2F', '/', 1)
+                list_item.setMimeType(mimeType)
+                list_item.setContentLookup(False)
+            except:
+                pass
 
     if not is_strm:
         if play_item.get_play_count() == 0:

--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -707,13 +707,15 @@ class VideoInfo(object):
 
         headers = self.MOBILE_HEADERS.copy()
         headers['Accept'] = '*/*'
+        if self._access_token:
+            headers['Authorization'] = 'Bearer %s' % self._access_token
 
         # Make a set of URL-quoted headers to be sent to Kodi.
         curl_headers = ''
-        # Cookies don't seem to be used by the YT player.
+        # Cookies don't seem to be used by the YT player when requesting media.
         #if cookies:
-        #    curl_headers = 'Cookie={cookies}'.format(
-        #        cookies = urllib.parse.quote(
+        #    curl_headers = 'Cookie={allCookies}'.format(
+        #        allCookies = urllib.parse.quote(
         #            '; '.join('{0}={1}'.format(c.name, c.value) for c in cookies)
         #        )
         #    )


### PR DESCRIPTION
### Edit: For anyone dropping by, this PR had a bug.
**If you want to grab the files for testing, you should take the ones from anxdpanic's fix in this later PR:** https://github.com/anxdpanic/plugin.video.youtube/pull/216/files

Original text below:

----

Special thanks to @tssajo for [pointing this solution out](https://github.com/anxdpanic/plugin.video.youtube/issues/211#issuecomment-941367476), and to @FireMasterK for [publishing it](https://github.com/TeamNewPipe/NewPipeExtractor/issues/562) in the first place.

This PR adds a specific API request that gets the `ytInitialPlayerResponse` data and it comes with all the streams without the `n` parameter and without the need to decipher the signature parameter. So that `n` calculation and signature deciphering code can be removed.

This PR also changes some header usage so that all video items use a User-Agent spoofing an Android device (otherwise Kodi sends out a MIME type request with Kodi's own User-Agent, making it obvious it's coming from a Kodi plugin).

Some testing needs to be done with age-restricted videos to see how / if they still work under these new changes, but logged-out playing is working again without throttling at least.