### PR TITLE
Don't assume addon is installed in home directory.

### DIFF
--- a/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context_ui.py
+++ b/resources/lib/youtube_plugin/kodion/impl/xbmc/xbmc_context_ui.py
@@ -152,7 +152,7 @@ class XbmcContextUI(AbstractContextUI):
         self._xbmc_addon.openSettings()
 
     def refresh_container(self):
-        script_uri = 'special://home/addons/%s/resources/lib/youtube_plugin/refresh.py' % self._context.get_id()
+        script_uri = "{}/resources/lib/youtube_plugin/refresh.py".format(self._xbmc_addon.getAddonInfo('path'))
         xbmc.executebuiltin('RunScript(%s)' % script_uri)
 
     @staticmethod

--- a/resources/lib/youtube_plugin/kodion/utils/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/utils/http_server.py
@@ -468,7 +468,7 @@ def get_http_server(address=None, port=None):
     except socket.error as e:
         logger.log_debug('HTTPServer: Failed to start |{address}:{port}| |{response}|'.format(address=address, port=port, response=str(e)))
         xbmcgui.Dialog().notification(addon.getAddonInfo('name'), str(e),
-                                      xbmc.translatePath('special://home/addons/{0!s}/icon.png'.format(addon.getAddonInfo('id'))),
+                                      "{}/icon.png".format(addon.getAddonInfo('path')),
                                       5000, False)
         return None
 


### PR DESCRIPTION
Addons can actually be installed elsewhere. For example, Nix opts to
install them in `special://xbmc/addons/`.

I got this suggestion to use `addon.getAddonInfo('path')` from
https://forum.kodi.tv/showthread.php?tid=274751. It seems to do what
it's supposed to!