### PR TITLE
Fix redirects through /supported_browsers

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/url_resolver.py
+++ b/resources/lib/youtube_plugin/youtube/helper/url_resolver.py
@@ -105,7 +105,7 @@ class CommonResolver(AbstractResolver, list):
                            'DNT': '1',
                            'Accept-Encoding': 'gzip, deflate',
                            'Accept-Language': 'en-US,en;q=0.8,de;q=0.6'}
-                response = requests.head(_url, headers=headers, verify=self._verify, allow_redirects=True)
+                response = requests.head(_url, headers=headers, verify=self._verify, allow_redirects=False)
                 if response.status_code == 304:
                     return url
 
@@ -130,6 +130,13 @@ class CommonResolver(AbstractResolver, list):
                     location = headers.get('Location', '')
                     if location:
                         return _loop(location, tries=tries - 1)
+
+                if response.status_code == 200:
+                    _url_components = urllib.parse.urlparse(_url)
+                    if _url_components.path == '/supported_browsers':
+                        _next_url = urllib.parse.parse_qs(_url_components.query)['next_url'][0]
+                        return _next_url
+
             except:
                 # do nothing
                 pass


### PR DESCRIPTION
A bit of a story about this one.

A few weeks ago, plugin version 6.8.18+matrix.1 stopped working for me with URLs sent from my phone through Yatse. I was aware that this use case takes a different code path in plugin.video.youtube depending on whether Kodi also has script.yatse.kodi installed - with script.yatse.kodi, plugin.video.youtube's uri2addon is used; without it, translation to plugin://plugin.video.youtube/play/?video_id=... happens "somewhere else". At the time I wanted a quick fix, disabled script.yatse.kodi and things would work for me. Yesterday I was inconvenienced by trying to share (non-YouTube) content that would not play without script.yatse.kodi's "magic", I saw that then sharing most (not all) YouTube links would again fail, and decided to have a look.

Adding logging to UrlResolver I saw that YouTube would redirect (typically from e.g. https://youtu.be/...) to an URL of the form https://www.youtube.com/supported_browsers?next_url=...

So I added a case to the CommonResolver to handle exactly that, and this is working well for me so far.

In preparing this PR, I hit another snag: A couple of lines above, the requests.head(_url, ...) call is changed in master from allow_redirects=False to allow_redirects=True. I can't put context to this change - I see that it's related to the uri2addon interface as well; I can just say that with allow_redirects=True, NO shared YouTube URLs that I tried would work for me: https://youtu.be/blah then just gets "resolved" to https://youtu.be/blah, and not a playable plugin://... item.
So I've set this back to False, this PR reflects what Works For Me(TM). ...

I'm happy to try things out and discuss ideas how to "more properly" fix this, as the case may be.