### PR TITLE
Improve /supported_browsers?next_url= handling

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/url_resolver.py
+++ b/resources/lib/youtube_plugin/youtube/helper/url_resolver.py
@@ -134,7 +134,15 @@ class CommonResolver(AbstractResolver, list):
                 if response.status_code == 200:
                     _url_components = urllib.parse.urlparse(_url)
                     if _url_components.path == '/supported_browsers':
-                        _next_url = urllib.parse.parse_qs(_url_components.query)['next_url'][0]
+                        # "sometimes", we get a redirect through an URL of the form https://.../supported_browsers?next_url=<urlencoded_next_url>&further=paramaters&stuck=here
+                        # put together query string from both what's encoded inside next_url and the remaining paramaters of this URL...
+                        _query = urllib.parse.parse_qs(_url_components.query) # top-level query string
+                        _nc = urllib.parse.urlparse(_query['next_url'][0]) # components of next_url
+                        _next_query = urllib.parse.parse_qs(_nc.query) # query string encoded inside next_url
+                        del _query['next_url'] # remove next_url from top level query string
+                        _next_query.update(_query) # add/overwrite all other params from top level query string
+                        _next_query = dict(map(lambda kv : (kv[0], kv[1][0]), _next_query.items())) # flatten to only use first argument of each param
+                        _next_url = urllib.parse.urlunsplit((_nc.scheme, _nc.netloc, _nc.path, urllib.parse.urlencode(_next_query), _nc.fragment)) # build new URL from these components
                         return _next_url
 
             except:


### PR DESCRIPTION
This is related and improves upon the recent [PR#238](https://github.com/anxdpanic/plugin.video.youtube/pull/283). 

It turns out that in certain cases, YouTube will redirect through this `supported_browsers` mechanism with parameters strewn apart - both encoded inside the next_url parameter, but also in the top-level query string, typically after the next_url parameter.

One use case which requires this: Facebook App on Android, YouTube link in a post, clicking that link opens a browser integrated in the Facebook App that shows the YouTube mobile website. This "special" browser's context menu has an "Open in Browser..." action, which allows to pick all other intents that match the given URL pattern. Yatse's "Play on Mediacenter" is among these. Choosing this, **and**  having script.yatse.kodi installed, takes the uri2addon route within plugin.video.youtube.

The URLs that would make it there would look like: https://m.youtube.com/watch?fbclid=IwAR34rbgF-HyXE9kQjWsa0EsXM9pmWL9d8e4AX9bcexelEB6yxEeEyMkz3c0&v=mBKN45QSebc&feature=youtu.be

In my case, YT chose to go through `/supported_browsers`, which resulted in the following URL: https://www.youtube.com/supported_browsers?next_url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fapp%3Ddesktop&fbclid=IwAR34rbgF-HyXE9kQjWsa0EsXM9pmWL9d8e4AX9bcexelEB6yxEeEyMkz3c0&v=mBKN45QSebc&feature=youtu.be

i.e. the host/path for the non-mobile version of single video playback is given within the `next_url` parameter, _but_ the video ID is given as a top level query parameter.

Since we can't know what parts of the URL get put where in this mechanism, I opted to take all top-level parameters, remove the next_url one, and merge any parameters from within next_url on top of that. The resulting URL looks plausible: https://www.youtube.com/watch?app=desktop&fbclid=IwAR34rbgF-HyXE9kQjWsa0EsXM9pmWL9d8e4AX9bcexelEB6yxEeEyMkz3c0&v=mBKN45QSebc&feature=youtu.be

And best of all, this works for playback further down the line.

I would like to add that python is not a "native" programming language of mine. It does feel like a lot of futzing around to "replace one part of the parsed URL object", but _nc.query is not writable, for example - so I have to pass all the different fragments on line 145 seperately.
I'm happy to hear about any more elegant - or more "usual" - solution to achieve the same thing.

Yet another point, maybe the headers configured some lines above could be updated to no longer trigger going through `/supported_browsers` - I assume this happens because YT thinks this is an unsupported browser. Which is a chasing game however, so I feel that being able to deal with `/supported_browsers` is useful functionality to have.