### PR TITLE
Allow for trailing slash when querying HTTP Server

### DIFF
--- a/resources/lib/youtube_plugin/kodion/utils/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/utils/http_server.py
@@ -67,7 +67,10 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         dash_proxy_enabled = addon.getSetting('kodion.mpd.videos') == 'true' and addon.getSetting('kodion.video.quality.mpd') == 'true'
         api_config_enabled = addon.getSetting('youtube.api.config.page') == 'true'
 
-        if self.path == '/client_ip':
+        # Strip trailing slash if present
+        stripped_path = self.path.rstrip('/')
+
+        if stripped_path == '/client_ip':
             client_json = json.dumps({"ip": "{ip}".format(ip=self.client_address[0])})
             self.send_response(200)
             self.send_header('Content-Type', 'application/json; charset=utf-8')
@@ -75,7 +78,7 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(client_json.encode('utf-8'))
 
-        if self.path != '/ping':
+        if stripped_path != '/ping':
             logger.log_debug('HTTPServer: Request uri path |{proxy_path}|'.format(proxy_path=self.path))
 
         if not self.connection_allowed():
@@ -98,7 +101,7 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 except IOError:
                     response = 'File Not Found: |{proxy_path}| -> |{file_path}|'.format(proxy_path=self.path, file_path=file_path.encode('utf-8'))
                     self.send_error(404, response)
-            elif api_config_enabled and self.path == '/api':
+            elif api_config_enabled and stripped_path == '/api':
                 html = self.api_config_page()
                 html = html.encode('utf-8')
                 self.send_response(200)
@@ -107,7 +110,7 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.end_headers()
                 for chunk in self.get_chunks(html):
                     self.wfile.write(chunk)
-            elif api_config_enabled and self.path.startswith('/api_submit'):
+            elif api_config_enabled and stripped_path.startswith('/api_submit'):
                 addon = xbmcaddon.Addon('plugin.video.youtube')
                 i18n = addon.getLocalizedString
                 xbmc.executebuiltin('Dialog.Close(addonsettings,true)')
@@ -156,7 +159,7 @@ class YouTubeRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 self.end_headers()
                 for chunk in self.get_chunks(html):
                     self.wfile.write(chunk)
-            elif self.path == '/ping':
+            elif stripped_path == '/ping':
                 self.send_error(204)
             else:
                 self.send_error(501)


### PR DESCRIPTION
This fixes #303 by stripping the path from trailing slashes.

This only affects path matching, actual operations can decide whether to use the unaltered path via `self.path` or the stripped version.