### PR TITLE
Use an Android YouTube app User-Agent and payload

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -734,9 +734,20 @@ class VideoInfo(object):
         #                                   'clientName': 'ANDROID', 'clientScreen': 'EMBED',
         #                                   'hl': self.language}}}
 
+        ANDROID_APP_VERSION = '18.14.41'
+        headers['User-Agent'] = 'com.google.android.youtube/%s ' \
+                                '(Linux; U; Android 12; US) gzip' % ANDROID_APP_VERSION
         payload = {'videoId': video_id,
-                   'context': {'client': {'clientVersion': '18.05.40', 'gl': self.region,
-                                          'clientName': 'ANDROID', 'hl': self.language}},
+                   'contentCheckOk': True,
+                   'racyCheckOk': True,
+                   'context': {'client': {'clientVersion': ANDROID_APP_VERSION,
+                                          'clientName': 'ANDROID',
+                                          'gl': self.region,
+                                          'hl': self.language,
+                                          'androidSdkVersion': 31,
+                                          'osName': 'Android',
+                                          'osVersion': '12',
+                                          'platform': 'MOBILE'}},
                    'thirdParty': {'embedUrl': 'https://google.com'}
         }
 


### PR DESCRIPTION
I've tested today some more, even the old "ANDROID" client name is back to working. Not sure what's going on there (Edit: it looks like it's the extended `payload` content that this PR adds that makes it work again. The old content was missing one or more parameters that their servers started requiring).  

So it can start with "ANDROID" as it was, and then do the other attempts with "ANDROID_EMBEDDED_PLAYER".

Anyway, the extra `payload` (AKA context) parameters were taken from Invidious:  
- https://github.com/iv-org/invidious/blob/961cae2b9a1e1dd780e3f92d55bbc7381b39ffe1/src/invidious/yt_backend/youtube_api.cr#L85-L94
- https://github.com/iv-org/invidious/blob/961cae2b9a1e1dd780e3f92d55bbc7381b39ffe1/src/invidious/yt_backend/youtube_api.cr#L291
- The app version "18.14.41" was taken from an APK build that they released (as seen in one of those APK mirror websites).  
- Edit: plus this link shared by @Wafflestyx with useful info: https://github.com/zerodytrash/YouTube-Internal-Clients#clients