### PR TITLE
add break for successful attempt

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -764,6 +764,9 @@ class VideoInfo(object):
                     if attempt == 0:
                         payload['context']['client']['clientName'] = 'ANDROID_EMBEDDED_PLAYER'
                         continue
+
+                ## if we get here then break out of loop as this attempt was successful
+                break
             except:
                 error_message = 'Failed to get player response for video_id "%s"' % video_id
                 self._context.log_error(error_message + '\n' + traceback.format_exc())


### PR DESCRIPTION
if playabilityStatus is not one of AGE_CHECK_REQUIRED, UNAVAILABLE, CONTENT_CHECK_REQUIRED then the loop actually runs through the attempt 0 & 1 regardless of the first API call result and the last API call response is passed down.

Add a break statement after the check of the playabilityStatus, to break out of the for loop.  We should only end up there if the playabilityStatus is not one of the three values we want to retry.