### PR TITLE
Update translations to reflect correct web server API config path

### DIFF
--- a/resources/language/resource.language.af_za/strings.po
+++ b/resources/language/resource.language.af_za/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.am_et/strings.po
+++ b/resources/language/resource.language.am_et/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ar_sa/strings.po
+++ b/resources/language/resource.language.ar_sa/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ast_es/strings.po
+++ b/resources/language/resource.language.ast_es/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.az_az/strings.po
+++ b/resources/language/resource.language.az_az/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.be_by/strings.po
+++ b/resources/language/resource.language.be_by/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.bg_bg/strings.po
+++ b/resources/language/resource.language.bg_bg/strings.po
@@ -822,7 +822,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.bs_ba/strings.po
+++ b/resources/language/resource.language.bs_ba/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ca_es/strings.po
+++ b/resources/language/resource.language.ca_es/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.cs_cz/strings.po
+++ b/resources/language/resource.language.cs_cz/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Povolit konfigurační stránku API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.cy_gb/strings.po
+++ b/resources/language/resource.language.cy_gb/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.da_dk/strings.po
+++ b/resources/language/resource.language.da_dk/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Aktiver side med API-konfiguration"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ip-adresse>:<port>/api (se HTTP-server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ip-adresse>:<port>/youtube/api (se HTTP-server)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "API-Einrichtungsseite aktivieren"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddresse>:<port>/api (siehe HTTP-Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddresse>:<port>/youtube/api (siehe HTTP-Server)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.el_gr/strings.po
+++ b/resources/language/resource.language.el_gr/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Επέτρεψε την σελίδα ρυθμίσεων κλειδιών API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://διεύθυνσηIP:θύρα/api (βλέπε εξυπηρετητής HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://διεύθυνσηIP:θύρα/youtube/api (βλέπε εξυπηρετητής HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.en_au/strings.po
+++ b/resources/language/resource.language.en_au/strings.po
@@ -834,7 +834,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -834,7 +834,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.en_nz/strings.po
+++ b/resources/language/resource.language.en_nz/strings.po
@@ -830,7 +830,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.en_us/strings.po
+++ b/resources/language/resource.language.en_us/strings.po
@@ -835,7 +835,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.eo/strings.po
+++ b/resources/language/resource.language.eo/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.es_ar/strings.po
+++ b/resources/language/resource.language.es_ar/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Habilitar página de configuración API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<direccion_ip>:<puerto>/api (ver Servidor HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<direccion_ip>:<puerto>/youtube/api (ver Servidor HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.es_mx/strings.po
+++ b/resources/language/resource.language.es_mx/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Activar página de configuración API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<direccion_ip>:<puerto>/api (ver Servidor HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<direccion_ip>:<puerto>/youtube/api (ver Servidor HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.et_ee/strings.po
+++ b/resources/language/resource.language.et_ee/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.eu_es/strings.po
+++ b/resources/language/resource.language.eu_es/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.fa_af/strings.po
+++ b/resources/language/resource.language.fa_af/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.fa_ir/strings.po
+++ b/resources/language/resource.language.fa_ir/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -820,8 +820,8 @@ msgid "Enable API configuration page"
 msgstr "Käytä API:n määrityssivua"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ip-osoite>:<portti>/api (katso HTTP-palvelin)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ip-osoite>:<portti>/youtube/api (katso HTTP-palvelin)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.fo_fo/strings.po
+++ b/resources/language/resource.language.fo_fo/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.fr_ca/strings.po
+++ b/resources/language/resource.language.fr_ca/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -820,8 +820,8 @@ msgid "Enable API configuration page"
 msgstr "Activer la page de configuration de l'API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (voir serveur HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (voir serveur HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.gl_es/strings.po
+++ b/resources/language/resource.language.gl_es/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.he_il/strings.po
+++ b/resources/language/resource.language.he_il/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.hi_in/strings.po
+++ b/resources/language/resource.language.hi_in/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.hr_hr/strings.po
+++ b/resources/language/resource.language.hr_hr/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Omogući API stranicu podešavanja"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ip-adresa>:<ulaz>/api (pogledajte HTTP poslužitelj)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ip-adresa>:<ulaz>/youtube/api (pogledajte HTTP poslužitelj)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.hu_hu/strings.po
+++ b/resources/language/resource.language.hu_hu/strings.po
@@ -823,8 +823,8 @@ msgid "Enable API configuration page"
 msgstr "API beállítások oldal engedélyezése"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (lásd HTTP kiszolgáló)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (lásd HTTP kiszolgáló)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.hy_am/strings.po
+++ b/resources/language/resource.language.hy_am/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.id_id/strings.po
+++ b/resources/language/resource.language.id_id/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Aktifkan halaman konfigurasi API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (lihat server HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (lihat server HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.is_is/strings.po
+++ b/resources/language/resource.language.is_is/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.it_it/strings.po
+++ b/resources/language/resource.language.it_it/strings.po
@@ -827,8 +827,8 @@ msgid "Enable API configuration page"
 msgstr "Abilita pagina configurazione API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<indirizzoip>:<porta>/api (vedi Server HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<indirizzoip>:<porta>/youtube/api (vedi Server HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.ja_jp/strings.po
+++ b/resources/language/resource.language.ja_jp/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.kn_in/strings.po
+++ b/resources/language/resource.language.kn_in/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ko_kr/strings.po
+++ b/resources/language/resource.language.ko_kr/strings.po
@@ -823,8 +823,8 @@ msgid "Enable API configuration page"
 msgstr "API 설정 페이지 사용"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (HTTP 서버 참고)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (HTTP 서버 참고)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.lt_lt/strings.po
+++ b/resources/language/resource.language.lt_lt/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.lv_lv/strings.po
+++ b/resources/language/resource.language.lv_lv/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.mi/strings.po
+++ b/resources/language/resource.language.mi/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.mk_mk/strings.po
+++ b/resources/language/resource.language.mk_mk/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ml_in/strings.po
+++ b/resources/language/resource.language.ml_in/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.mn_mn/strings.po
+++ b/resources/language/resource.language.mn_mn/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ms_my/strings.po
+++ b/resources/language/resource.language.ms_my/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.mt_mt/strings.po
+++ b/resources/language/resource.language.mt_mt/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.my_mm/strings.po
+++ b/resources/language/resource.language.my_mm/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -826,8 +826,8 @@ msgid "Enable API configuration page"
 msgstr "API instellingen pagina inschakelen"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (zie HTTP-server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (zie HTTP-server)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.os_os/strings.po
+++ b/resources/language/resource.language.os_os/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.pl_pl/strings.po
+++ b/resources/language/resource.language.pl_pl/strings.po
@@ -823,8 +823,8 @@ msgid "Enable API configuration page"
 msgstr "Włącz stronę konfiguracji API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (zobacz serwer HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (zobacz serwer HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.pt_br/strings.po
+++ b/resources/language/resource.language.pt_br/strings.po
@@ -820,8 +820,8 @@ msgid "Enable API configuration page"
 msgstr "Ativar página de configuração da API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (ver Servidor HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (ver Servidor HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -823,7 +823,7 @@ msgid "Enable API configuration page"
 msgstr "Activar página de configuração API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ro_ro/strings.po
+++ b/resources/language/resource.language.ro_ro/strings.po
@@ -823,7 +823,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ru_ru/strings.po
+++ b/resources/language/resource.language.ru_ru/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "Включить страницу настроек API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (смотрите HTTP сервер)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (смотрите HTTP сервер)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.si_lk/strings.po
+++ b/resources/language/resource.language.si_lk/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.sk_sk/strings.po
+++ b/resources/language/resource.language.sk_sk/strings.po
@@ -823,8 +823,8 @@ msgid "Enable API configuration page"
 msgstr "Zapnúť konfiguračnú stránku API"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ip_adresa>:<port>/api (viď server HTTP)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ip_adresa>:<port>/youtube/api (viď server HTTP)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.sl_si/strings.po
+++ b/resources/language/resource.language.sl_si/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.sq_al/strings.po
+++ b/resources/language/resource.language.sq_al/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.sr_rs/strings.po
+++ b/resources/language/resource.language.sr_rs/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/resources/language/resource.language.sr_rs@latin/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.szl/strings.po
+++ b/resources/language/resource.language.szl/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.ta_in/strings.po
+++ b/resources/language/resource.language.ta_in/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.te_in/strings.po
+++ b/resources/language/resource.language.te_in/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.tg_tj/strings.po
+++ b/resources/language/resource.language.tg_tj/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.th_th/strings.po
+++ b/resources/language/resource.language.th_th/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.tr_tr/strings.po
+++ b/resources/language/resource.language.tr_tr/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "API yapılandırma sayfasını etkinleştir"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (bkz. HTTP Sunucusu)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (bkz. HTTP Sunucusu)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.uk_ua/strings.po
+++ b/resources/language/resource.language.uk_ua/strings.po
@@ -822,7 +822,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.uz_uz/strings.po
+++ b/resources/language/resource.language.uz_uz/strings.po
@@ -824,7 +824,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.vi_vn/strings.po
+++ b/resources/language/resource.language.vi_vn/strings.po
@@ -825,7 +825,7 @@ msgid "Enable API configuration page"
 msgstr ""
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
 msgstr ""
 
 msgctxt "#30634"

--- a/resources/language/resource.language.zh_cn/strings.po
+++ b/resources/language/resource.language.zh_cn/strings.po
@@ -823,8 +823,8 @@ msgid "Enable API configuration page"
 msgstr "允许 API 配置页面"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (请参阅 HTTP 服务器)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (请参阅 HTTP 服务器)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"

--- a/resources/language/resource.language.zh_tw/strings.po
+++ b/resources/language/resource.language.zh_tw/strings.po
@@ -825,8 +825,8 @@ msgid "Enable API configuration page"
 msgstr "啟用 API 設定頁面"
 
 msgctxt "#30633"
-msgid "http://<ipaddress>:<port>/api (see HTTP Server)"
-msgstr "http://<ipaddress>:<port>/api (請看 HTTP 伺服器)"
+msgid "http://<ipaddress>:<port>/youtube/api (see HTTP Server)"
+msgstr "http://<ipaddress>:<port>/youtube/api (請看 HTTP 伺服器)"
 
 msgctxt "#30634"
 msgid "YouTube Add-on API Configuration"


### PR DESCRIPTION
API configuration path changed from
```
http://<ipaddress>:<port>/api
```

to

```
http://<ipaddress>:<port>/youtube/api
```

Update translations to reflect this change in the settings UI