### PR TITLE
Enable profiler if debug logging is enabled

### DIFF
--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
 import json
-import os
 import sys
 import weakref
 
@@ -24,7 +23,6 @@ from ...compatibility import (
     xbmc,
     xbmcaddon,
     xbmcplugin,
-    xbmcvfs,
 )
 from ...constants import ADDON_ID, content, sort
 from ...player import XbmcPlayer, XbmcPlaylist
@@ -369,13 +367,6 @@ class XbmcContext(AbstractContext):
 
     def get_data_path(self):
         return self._data_path
-
-    def get_debug_path(self):
-        if not self._debug_path:
-            self._debug_path = os.path.join(self.get_data_path(), 'debug')
-            if not xbmcvfs.exists(self._debug_path):
-                xbmcvfs.mkdir(self._debug_path)
-        return self._debug_path
 
     def get_addon_path(self):
         return self._addon_path

--- a/resources/lib/youtube_plugin/kodion/debug.py
+++ b/resources/lib/youtube_plugin/kodion/debug.py
@@ -10,9 +10,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-import json
 import os
-from io import open
 
 from .logger import log_debug
 
@@ -29,35 +27,6 @@ def debug_here(host='localhost'):
     # noinspection PyUnresolvedReferences,PyPackageRequirements
     import pydevd
     pydevd.settrace(host, stdoutToServer=True, stderrToServer=True)
-
-
-def runtime(context, addon_version, elapsed, single_file=True):
-    if not single_file:
-        filename_path_part = context.get_path().lstrip('/').rstrip('/').replace('/', '_')
-        debug_file_name = 'runtime_%s-%s.json' % (filename_path_part, addon_version)
-        default_contents = {"runtimes": []}
-    else:
-        debug_file_name = 'runtime-%s.json' % addon_version
-        default_contents = {"runtimes": {}}
-
-    debug_file = os.path.join(context.get_debug_path(), debug_file_name)
-    with open(debug_file, 'a') as _:
-        pass  # touch
-
-    with open(debug_file, 'r', encoding='utf-8') as f:
-        contents = f.read()
-
-    with open(debug_file, 'w', encoding='utf-8') as f:
-        contents = json.loads(contents) if contents else default_contents
-        if not single_file:
-            items = contents.get('runtimes', [])
-            items.append({"path": context.get_path(), "parameters": context.get_params(), "runtime": round(elapsed, 4)})
-            contents['runtimes'] = items
-        else:
-            items = contents.get('runtimes', {}).get(context.get_path(), [])
-            items.append({"parameters": context.get_params(), "runtime": round(elapsed, 4)})
-            contents['runtimes'][context.get_path()] = items
-        f.write(json.dumps(contents, indent=4))
 
 
 class Profiler(object):

--- a/resources/lib/youtube_plugin/kodion/debug.py
+++ b/resources/lib/youtube_plugin/kodion/debug.py
@@ -20,12 +20,18 @@ def debug_here(host='localhost'):
 
     for comp in sys.path:
         if comp.find('addons') != -1:
-            pydevd_path = os.path.normpath(os.path.join(comp, os.pardir, 'script.module.pydevd', 'lib'))
+            pydevd_path = os.path.normpath(os.path.join(
+                comp,
+                os.pardir,
+                'script.module.pydevd',
+                'lib',
+            ))
             sys.path.append(pydevd_path)
             break
 
     # noinspection PyUnresolvedReferences,PyPackageRequirements
     import pydevd
+
     pydevd.settrace(host, stdoutToServer=True, stderrToServer=True)
 
 
@@ -36,11 +42,13 @@ class Profiler(object):
 
     from cProfile import Profile as _Profile
     from pstats import Stats as _Stats
+
     try:
         from StringIO import StringIO as _StringIO
     except ImportError:
         from io import StringIO as _StringIO
     from functools import wraps as _wraps
+
     _wraps = staticmethod(_wraps)
     from weakref import ref as _ref
 
@@ -80,7 +88,8 @@ class Profiler(object):
             self._create_profiler()
 
     def __del__(self):
-        self.__class__._instances.discard(self)  # pylint: disable=protected-access
+        # pylint: disable=protected-access
+        self.__class__._instances.discard(self)
 
     def __enter__(self):
         if not self._enabled:

--- a/resources/lib/youtube_plugin/kodion/plugin_runner.py
+++ b/resources/lib/youtube_plugin/kodion/plugin_runner.py
@@ -12,23 +12,18 @@ from __future__ import absolute_import, division, unicode_literals
 
 import copy
 import platform
-import timeit
 
-from . import debug
 from .context import XbmcContext
 from .plugin import XbmcPlugin
 
 
 __all__ = ('run',)
 
-__DEBUG_RUNTIME = False
-__DEBUG_RUNTIME_SINGLE_FILE = False
 
 __PLUGIN__ = XbmcPlugin()
 
 
 def run(provider, context=None):
-    start_time = timeit.default_timer()
 
     if not context:
         context = XbmcContext()
@@ -60,13 +55,3 @@ def run(provider, context=None):
     __PLUGIN__.run(provider, context)
     provider.tear_down(context)
 
-    elapsed = timeit.default_timer() - start_time
-
-    if __DEBUG_RUNTIME:
-        debug.runtime(context,
-                      addon_version,
-                      elapsed,
-                      single_file=__DEBUG_RUNTIME_SINGLE_FILE)
-
-    context.log_debug('Shutdown of Kodion after |{elapsed:.4}| seconds'
-                      .format(elapsed=elapsed))

--- a/resources/lib/youtube_plugin/kodion/plugin_runner.py
+++ b/resources/lib/youtube_plugin/kodion/plugin_runner.py
@@ -10,31 +10,37 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-import copy
-import platform
-
-from .context import XbmcContext
-from .plugin import XbmcPlugin
-
 
 __all__ = ('run',)
 
 
-__PLUGIN__ = XbmcPlugin()
-
-
 def run(provider, context=None):
+    from .compatibility import xbmc
 
+    profiler = xbmc.getCondVisibility('System.GetBool(debug.showloginfo)')
+    if profiler:
+        from .debug import Profiler
+
+        profiler = Profiler(enabled=True, lazy=False)
+
+    from copy import deepcopy
+    from platform import python_version
+
+    from .plugin import XbmcPlugin
+
+    plugin = XbmcPlugin()
     if not context:
+        from .context import XbmcContext
+
         context = XbmcContext()
 
     context.log_debug('Starting Kodion framework by bromix...')
 
     addon_version = context.get_version()
-    python_version = 'Python {0}'.format(platform.python_version())
+    python_version = 'Python {0}'.format(python_version())
 
     redacted = '<redacted>'
-    params = copy.deepcopy(context.get_params())
+    params = deepcopy(context.get_params())
     if 'api_key' in params:
         params['api_key'] = redacted
     if 'client_id' in params:
@@ -52,6 +58,8 @@ def run(provider, context=None):
                                path=context.get_path(),
                                params=params))
 
-    __PLUGIN__.run(provider, context)
+    plugin.run(provider, context)
     provider.tear_down(context)
 
+    if profiler:
+        profiler.print_stats()


### PR DESCRIPTION
There have been reports of slowdowns in recent versions of the plugin.

This enables the profiler that was added in recent versions, automatically, when debug logging is enabled to try and get more data to better identify the issue.

File based runtime logging removed as it is more difficult to get precise information, and may be difficult for users to retrieve the runtimes log on certain platforms.