### PR TITLE
v7.0.5

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.5+beta.5" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.5" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.5+beta.4" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.5+beta.5" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+## v7.0.5+beta.5
+### Fixed
+- Fix typo causing no fractional frame rate hinting to fail #679
+
 ## v7.0.5+beta.4
 ### Fixed
 - Fix typo that caused android player requests to fail

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,39 @@
+## v7.0.5
+### Fixed
+- Fix typo causing no fractional frame rate hinting to fail #679
+- Fix typo that caused android player requests to fail
+- Fix error message when rating video #666
+- Fix various issues with Kodi 18 and Python 2 #668
+- Fix issues with video playback #654, #659, #663
+- Fix typos #661
+- Fix typo that prevented videos from being listed in Kodi versions prior to v20 #662
+- Try to prevent Kodi freezing when settings are updated and container is reloaded
+- Fix lockups when using xbmc.executebuiltin #647, #653
+- Fix searching for preferred language subtitles not using non-region specific subtitles
+- Fix not being able to set custom watch later history playlist per user #646
+- Update workarounds for multiple busy dialog crashes #640, #649
+- Fix playing incorrect video when player request is blocked #654
+
+### Changed
+- Update language used for maintenance action prompts that clear data
+- Display search history as list rather than videos
+- Update Setup Wizard
+  - Add settings for Raspberry Pi 3 class devices (1080p30, VP9 enabled)
+  - Update settings for Raspberry Pi 4 class devices (1080p60, VP9 enabled)
+  - Move option to disable list details to last step in wizard
+- Shared playlist play using default order without prompting
+- Removed dependency on script.module.infotagger #479
+- Removed Nexus specific releases
+  - Matrix releases will now work in Kodi v19+
+  - Leia releases will work, but are unsupported, for Kodi v18 only
+- Updated client versions used for player requests
+  - Use iOS client as fallback for default client selection
+
+### New
+- Add new client that may provide 1080p non-adaptive formats
+  - Can be accessed as Alternate #2
+- Allow channel name to be displayed/sorted in listing depending on sort order #644
+
 ## v7.0.5+beta.5
 ### Fixed
 - Fix typo causing no fractional frame rate hinting to fail #679

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -534,7 +534,7 @@ class XbmcContext(AbstractContext):
                                    'properties': ['enabled']})
         try:
             return response['result']['addon']['enabled'] is True
-        except KeyError:
+        except (KeyError, TypeError):
             error = response.get('error', {})
             self.log_error('XbmcContext.addon_enabled error - |{0}: {1}|'
                            .format(error.get('code', 'unknown'),
@@ -547,7 +547,7 @@ class XbmcContext(AbstractContext):
                                    'enabled': enabled})
         try:
             return response['result'] == 'OK'
-        except KeyError:
+        except (KeyError, TypeError):
             error = response.get('error', {})
             self.log_error('XbmcContext.set_addon_enabled error - |{0}: {1}|'
                            .format(error.get('code', 'unknown'),

--- a/resources/lib/youtube_plugin/kodion/utils/methods.py
+++ b/resources/lib/youtube_plugin/kodion/utils/methods.py
@@ -323,10 +323,16 @@ def merge_dicts(item1, item2, templates=None, _=Ellipsis):
     return new or _
 
 
-def get_kodi_setting_value(setting):
+def get_kodi_setting_value(setting, process=None):
     response = jsonrpc(method='Settings.GetSettingValue',
                        params={'setting': setting})
-    return response.get('result', {}).get('value')
+    try:
+        value = response['result']['value']
+        if process:
+            return process(value)
+    except (KeyError, TypeError, ValueError):
+        return None
+    return value
 
 
 def get_kodi_setting_bool(setting):

--- a/resources/lib/youtube_plugin/kodion/utils/system_version.py
+++ b/resources/lib/youtube_plugin/kodion/utils/system_version.py
@@ -38,7 +38,7 @@ class SystemVersion(object):
             self._version = (version_installed.get('major', 1),
                              version_installed.get('minor', 0))
             self._appname = response['result']['name']
-        except:
+        except (KeyError, TypeError):
             self._version = (1, 0)  # Frodo
             self._appname = 'Unknown Application'
 

--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -596,7 +596,7 @@ class VideoInfo(YouTubeRequestClient):
         48: '48000/1000',  # 48.00 fps
         50: '50000/1000',  # 50.00 fps
         60: '60000/1000',  # 60.00 fps
-    },
+    }
     FRACTIONAL_FPS_SCALE = {
         0: '{0}000/1000',  # --.00 fps
         24: '24000/1001',  # 23.976 fps


### PR DESCRIPTION
## v7.0.5
### Fixed
- Fix typo causing no fractional frame rate hinting to fail #679
- Fix typo that caused android player requests to fail
- Fix error message when rating video #666
- Fix various issues with Kodi 18 and Python 2 #668
- Fix issues with video playback #654, #659, #663
- Fix typos #661
- Fix typo that prevented videos from being listed in Kodi versions prior to v20 #662
- Try to prevent Kodi freezing when settings are updated and container is reloaded
- Fix lockups when using xbmc.executebuiltin #647, #653
- Fix searching for preferred language subtitles not using non-region specific subtitles
- Fix not being able to set custom watch later history playlist per user #646
- Update workarounds for multiple busy dialog crashes #640, #649
- Fix playing incorrect video when player request is blocked #654

### Changed
- Update language used for maintenance action prompts that clear data
- Display search history as list rather than videos
- Update Setup Wizard
  - Add settings for Raspberry Pi 3 class devices (1080p30, VP9 enabled)
  - Update settings for Raspberry Pi 4 class devices (1080p60, VP9 enabled)
  - Move option to disable list details to last step in wizard
- Shared playlist play using default order without prompting
- Removed dependency on script.module.infotagger #479
- Removed Nexus specific releases
  - Matrix releases will now work in Kodi v19+
  - Leia releases will work, but are unsupported, for Kodi v18 only
- Updated client versions used for player requests
  - Use iOS client as fallback for default client selection

### New
- Add new client that may provide 1080p non-adaptive formats
  - Can be accessed as Alternate #2
- Allow channel name to be displayed/sorted in listing depending on sort order #644