### PR TITLE
v7.0.6+beta.2

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.6+beta.1" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.6+beta.2" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,12 @@
+## v7.0.6+beta.2
+### Fixed
+- Further fixes for multiple busy dialog crash workaround
+  - Possibly fix issues reported in comments of #704
+- Update error checks to avoid unnecessary retries of player request
+
+### Changed
+- Make "Support alternative player" and "Use YouTube website urls with default player" mutually exclusive options
+
 ## v7.0.6+beta.1
 ### Fixed
 - Improve updating containers and (re)loading windows #681
@@ -7,8 +16,7 @@
 
 ### Changed
 - Setup Wizard default settings now disable pre-downloading subtitles if MPEG-DASH is enabled
-- Ask for quality, Play with subtitles, Play audio only context menu items only displayed if
-  associated setting is not already enabled
+- Ask for quality, Play with subtitles, Play audio only context menu items only displayed if associated setting is not already enabled
 - Only make extra request for subtitles for Android client when all subtitle languages are enabled
 - Overhaul alternative player support due to Kodi changes and also improve external player support
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,10 +2,14 @@
 ### Fixed
 - Further fixes for multiple busy dialog crash workaround
   - Possibly fix issues reported in comments of #704
-- Update error checks to avoid unnecessary retries of player request
+- Update error checks to avoid unnecessary retries of player requests
 
 ### Changed
-- Make "Support alternative player" and "Use YouTube website urls with default player" mutually exclusive options
+- Make "Support alternative player" and "Use YouTube website urls with default player" mutually exclusive options #692
+- Enable OPUS audio by default #537
+- Enable MPEG-DASH for live streams by default #680
+- Setup Wizard will prompt to run when plugin first opens after updating, in order to update default settings
+- http server will shutdown on idle timeout #699
 
 ## v7.0.6+beta.1
 ### Fixed

--- a/resources/lib/youtube_plugin/kodion/compatibility/__init__.py
+++ b/resources/lib/youtube_plugin/kodion/compatibility/__init__.py
@@ -132,12 +132,8 @@ except ImportError:
 # Kodi v20+
 if hasattr(xbmcgui.ListItem, 'setDateTime'):
     def datetime_infolabel(datetime_obj):
-        if datetime_obj:
-            return datetime_obj.replace(microsecond=0, tzinfo=None).isoformat()
-        return ''
+        return datetime_obj.replace(microsecond=0, tzinfo=None).isoformat()
 # Compatibility shims for Kodi v18 and v19
 else:
     def datetime_infolabel(datetime_obj):
-        if datetime_obj:
-            return datetime_obj.strftime('%d.%m.%Y')
-        return ''
+        return datetime_obj.strftime('%d.%m.%Y')

--- a/resources/lib/youtube_plugin/kodion/constants/__init__.py
+++ b/resources/lib/youtube_plugin/kodion/constants/__init__.py
@@ -34,6 +34,7 @@ VALUE_FROM_STR = {
 
 BUSY_FLAG = 'busy'
 SWITCH_PLAYER_FLAG = 'switch_player'
+PLAYLIST_POSITION = 'playlist_position'
 WAIT_FLAG = 'builtin_running'
 
 __all__ = (
@@ -42,6 +43,7 @@ __all__ = (
     'BUSY_FLAG',
     'DATA_PATH',
     'MEDIA_PATH',
+    'PLAYLIST_POSITION',
     'RESOURCE_PATH',
     'SWITCH_PLAYER_FLAG',
     'TEMP_PATH',

--- a/resources/lib/youtube_plugin/kodion/context/abstract_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/abstract_context.py
@@ -387,6 +387,10 @@ class AbstractContext(object):
         raise NotImplementedError()
 
     @staticmethod
+    def get_infobool(name):
+        raise NotImplementedError()
+
+    @staticmethod
     def get_infolabel(name):
         raise NotImplementedError()
 

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -370,14 +370,14 @@ class XbmcContext(AbstractContext):
     @staticmethod
     def get_language():
         language = xbmc.getLanguage(format=xbmc.ISO_639_1, region=True)
-        lang_code, seperator, region = language.partition('-')
+        lang_code, separator, region = language.partition('-')
         if not lang_code:
             language = xbmc.getLanguage(format=xbmc.ISO_639_2, region=False)
-            lang_code, seperator, region = language.partition('-')
+            lang_code, separator, region = language.partition('-')
         if not lang_code:
             return 'en-US'
         if region:
-            return seperator.join((lang_code.lower(), region.upper()))
+            return separator.join((lang_code.lower(), region.upper()))
         return lang_code
 
     def get_language_name(self, lang_id=None):
@@ -549,7 +549,7 @@ class XbmcContext(AbstractContext):
 
     @staticmethod
     def sleep(timeout=None):
-        wait(timeout)
+        return wait(timeout)
 
     def addon_enabled(self, addon_id):
         response = jsonrpc(method='Addons.GetAddonDetails',
@@ -590,7 +590,7 @@ class XbmcContext(AbstractContext):
             if self.addon_enabled('inputstream.adaptive'):
                 success = True
             elif self.get_ui().on_yes_no_input(
-                self.get_name(), self.localize('isa.enable.confirm')
+                    self.get_name(), self.localize('isa.enable.confirm')
             ):
                 success = self.set_addon_enabled('inputstream.adaptive')
             else:

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -661,6 +661,10 @@ class XbmcContext(AbstractContext):
         return self.get_ui().get_property('abort_requested').lower() == 'true'
 
     @staticmethod
+    def get_infobool(name):
+        return xbmc.getCondVisibility(name)
+
+    @staticmethod
     def get_infolabel(name):
         return xbmc.getInfoLabel(name)
 

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -610,8 +610,8 @@ class XbmcContext(AbstractContext):
         'ttml': loose_version('20.0.0'),
         # audio codecs
         'vorbis': loose_version('2.3.14'),
-        # unknown when Opus audio support was implemented
-        'opus': loose_version('19.0.0'),
+        # Opus audio enabled in Kodi v21+ which fixes stalls after seek
+        'opus': loose_version('21.0.0'),
         'mp4a': True,
         'ac-3': loose_version('2.1.15'),
         'ec-3': loose_version('2.1.15'),

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -374,6 +374,9 @@ class XbmcContext(AbstractContext):
         if not lang_code:
             language = xbmc.getLanguage(format=xbmc.ISO_639_2, region=False)
             lang_code, separator, region = language.partition('-')
+            if lang_code != 'fil':
+                lang_code = lang_code[:2]
+            region = region[:2]
         if not lang_code:
             return 'en-US'
         if region:

--- a/resources/lib/youtube_plugin/kodion/debug.py
+++ b/resources/lib/youtube_plugin/kodion/debug.py
@@ -206,11 +206,12 @@ class Profiler(object):
                 self._profiler,
                 stream=output_stream
             ).strip_dirs().sort_stats('cumulative', 'time').print_stats(50)
+            output = output_stream.getvalue()
         # Occurs when no stats were able to be generated from profiler
         except TypeError:
-            pass
-        output = output_stream.getvalue()
-        output_stream.close()
+            output = 'Profiler: unable to generate stats'
+        finally:
+            output_stream.close()
 
         if reuse:
             # If stats are accumulating then enable existing/new profiler

--- a/resources/lib/youtube_plugin/kodion/items/base_item.py
+++ b/resources/lib/youtube_plugin/kodion/items/base_item.py
@@ -143,14 +143,13 @@ class BaseItem(object):
         self._date = date_time
 
     def get_date(self, as_text=False, short=False, as_info_label=False):
-        if not self._date:
-            return ''
-        if short:
-            return self._date.date().strftime('%x')
-        if as_text:
-            return self._date.strftime('%x %X')
-        if as_info_label:
-            return datetime_infolabel(self._date)
+        if self._date:
+            if as_info_label:
+                return datetime_infolabel(self._date)
+            if short:
+                return self._date.date().strftime('%x')
+            if as_text:
+                return self._date.strftime('%x %X')
         return self._date
 
     def set_dateadded(self, year, month, day, hour=0, minute=0, second=0):
@@ -165,12 +164,11 @@ class BaseItem(object):
         self._dateadded = date_time
 
     def get_dateadded(self, as_text=False, as_info_label=False):
-        if not self._dateadded:
-            return ''
-        if as_text:
-            return self._dateadded.strftime('%x %X')
-        if as_info_label:
-            return datetime_infolabel(self._date)
+        if self._dateadded:
+            if as_info_label:
+                return datetime_infolabel(self._dateadded)
+            if as_text:
+                return self._dateadded.strftime('%x %X')
         return self._dateadded
 
     def set_added_utc(self, date_time):

--- a/resources/lib/youtube_plugin/kodion/items/base_item.py
+++ b/resources/lib/youtube_plugin/kodion/items/base_item.py
@@ -239,4 +239,7 @@ class _Encoder(json.JSONEncoder):
                 }
         else:
             output = obj
-        return output if nested else super(_Encoder, self).encode(output)
+
+        if nested:
+            return to_str(output)
+        return super(_Encoder, self).encode(output)

--- a/resources/lib/youtube_plugin/kodion/items/video_item.py
+++ b/resources/lib/youtube_plugin/kodion/items/video_item.py
@@ -123,12 +123,11 @@ class VideoItem(BaseItem):
         self._premiered = date_time.date()
 
     def get_premiered(self, as_text=True, as_info_label=False):
-        if not self._premiered:
-            return ''
-        if as_info_label:
-            return self._premiered.isoformat()
-        if as_text:
-            return self._premiered.strftime('%x')
+        if self._premiered:
+            if as_info_label:
+                return self._premiered.isoformat()
+            if as_text:
+                return self._premiered.strftime('%x')
         return self._premiered
 
     def set_plot(self, plot):
@@ -228,12 +227,11 @@ class VideoItem(BaseItem):
         self._aired = date_time.date()
 
     def get_aired(self, as_text=True, as_info_label=False):
-        if not self._aired:
-            return ''
-        if as_info_label:
-            return self._aired.isoformat()
-        if as_text:
-            return self._aired.strftime('%x')
+        if self._aired:
+            if as_info_label:
+                return self._aired.isoformat()
+            if as_text:
+                return self._aired.strftime('%x')
         return self._aired
 
     def set_scheduled_start_utc(self, date_time):
@@ -319,8 +317,9 @@ class VideoItem(BaseItem):
         self._last_played = last_played
 
     def get_last_played(self, as_info_label=False):
-        if as_info_label:
-            return datetime_infolabel(self._last_played)
+        if self._last_played:
+            if as_info_label:
+                return datetime_infolabel(self._last_played)
         return self._last_played
 
     def set_start_percent(self, start_percent):

--- a/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
@@ -366,7 +366,9 @@ def video_playback_item(context, video_item, show_fanart=None):
                                 if current_system_version.compatible(19, 0) else
                                 'inputstreamaddon')
         props[inputstream_property] = 'inputstream.adaptive'
-        props['inputstream.adaptive.manifest_type'] = manifest_type
+
+        if not current_system_version.compatible(21, 0):
+            props['inputstream.adaptive.manifest_type'] = manifest_type
 
         if headers:
             props['inputstream.adaptive.manifest_headers'] = headers

--- a/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
@@ -381,8 +381,10 @@ def video_playback_item(context, video_item, show_fanart=None):
             mime_type = uri.split('mime=', 1)[1].split('&', 1)[0]
             mime_type = mime_type.replace('%2F', '/')
 
-        if (not settings.support_alternative_player()
-                and headers and uri.startswith('http')):
+        if (headers and uri.startswith('http') and not (
+                settings.default_player_web_urls()
+                or (is_external and settings.alternative_player_web_urls())
+        )):
             kwargs['path'] = '|'.join((uri, headers))
 
     list_item = xbmcgui.ListItem(**kwargs)

--- a/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
@@ -85,7 +85,9 @@ class ServiceMonitor(xbmc.Monitor):
                     'plugin://{0}/'.format(ADDON_ID))):
             xbmc.executebuiltin('Container.Refresh')
 
-        use_httpd = settings.use_isa() or settings.api_config_page()
+        use_httpd = (settings.use_isa()
+                     or settings.api_config_page()
+                     or settings.support_alternative_player())
         address, port = get_connect_address()
         whitelist = settings.httpd_whitelist()
 

--- a/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
@@ -168,3 +168,6 @@ class ServiceMonitor(xbmc.Monitor):
     @staticmethod
     def ping_httpd():
         return httpd_status()
+
+    def httpd_required(self):
+        return self._use_httpd

--- a/resources/lib/youtube_plugin/kodion/player/xbmc/xbmc_playlist.py
+++ b/resources/lib/youtube_plugin/kodion/player/xbmc/xbmc_playlist.py
@@ -171,12 +171,15 @@ class XbmcPlaylist(AbstractPlaylist):
         context.log_debug('Playing from playlist position: {0}'
                           .format(position))
 
+        if not resume:
+            xbmc.Player().play(self._playlist, startpos=position - 1)
+            return
         # JSON Player.Open can be too slow but is needed if resuming is enabled
         jsonrpc(method='Player.Open',
                 params={'item': {'playlistid': self._playlist.getPlayListId(),
                                  # Convert 1 indexed to 0 indexed position
                                  'position': position - 1}},
-                options={'resume': resume},
+                options={'resume': True},
                 no_response=True)
 
     def get_position(self, offset=0):

--- a/resources/lib/youtube_plugin/kodion/plugin_runner.py
+++ b/resources/lib/youtube_plugin/kodion/plugin_runner.py
@@ -15,9 +15,12 @@ __all__ = ('run',)
 
 
 def run(provider, context=None):
-    from .compatibility import xbmc
+    if not context:
+        from .context import XbmcContext
 
-    profiler = xbmc.getCondVisibility('System.GetBool(debug.showloginfo)')
+        context = XbmcContext()
+
+    profiler = context.get_infobool('System.GetBool(debug.showloginfo)')
     if profiler:
         from .debug import Profiler
 
@@ -29,10 +32,6 @@ def run(provider, context=None):
     from .plugin import XbmcPlugin
 
     plugin = XbmcPlugin()
-    if not context:
-        from .context import XbmcContext
-
-        context = XbmcContext()
 
     context.log_debug('Starting Kodion framework by bromix...')
 

--- a/resources/lib/youtube_plugin/kodion/script_actions.py
+++ b/resources/lib/youtube_plugin/kodion/script_actions.py
@@ -41,16 +41,16 @@ def _config_actions(context, action, *_args):
             xbmc.executebuiltin('InstallAddon(script.module.inputstreamhelper)')
 
     elif action == 'subtitles':
-        sub_lang = context.get_subtitle_language()
+        kodi_sub_lang = context.get_subtitle_language()
         plugin_lang = settings.get_language()
         sub_selection = settings.get_subtitle_selection()
 
-        if not sub_lang:
+        if not kodi_sub_lang:
             preferred = (plugin_lang,)
-        elif sub_lang.partition('-')[0] != plugin_lang.partition('-')[0]:
-            preferred = (sub_lang, plugin_lang)
+        elif kodi_sub_lang.partition('-')[0] != plugin_lang.partition('-')[0]:
+            preferred = (kodi_sub_lang, plugin_lang)
         else:
-            preferred = (sub_lang,)
+            preferred = (kodi_sub_lang,)
 
         fallback = ('ASR' if preferred[0].startswith('en') else
                     context.get_language_name('en'))

--- a/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
+++ b/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
@@ -112,14 +112,13 @@ class AbstractSettings(object):
         if value is not None:
             return self.set_bool(settings.DEFAULT_PLAYER_WEB_URLS, value)
         if self.support_alternative_player():
-            return self.get_bool(settings.DEFAULT_PLAYER_WEB_URLS, False)
-        return False
+            return False
+        return self.get_bool(settings.DEFAULT_PLAYER_WEB_URLS, False)
 
     def alternative_player_web_urls(self, value=None):
         if value is not None:
             return self.set_bool(settings.ALTERNATIVE_PLAYER_WEB_URLS, value)
         if (self.support_alternative_player()
-                and not self.default_player_web_urls()
                 and not self.alternative_player_adaptive()):
             return self.get_bool(settings.ALTERNATIVE_PLAYER_WEB_URLS, False)
         return False

--- a/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
+++ b/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
@@ -96,7 +96,7 @@ class AbstractSettings(object):
 
     def is_setup_wizard_enabled(self):
         # Increment min_required on new release to enable oneshot on first run
-        min_required = 2
+        min_required = 3
         forced_runs = self.get_int(settings.SETUP_WIZARD_RUNS, min_required - 1)
         if forced_runs < min_required:
             self.set_int(settings.SETUP_WIZARD_RUNS, min_required)

--- a/resources/lib/youtube_plugin/youtube/helper/subtitles.py
+++ b/resources/lib/youtube_plugin/youtube/helper/subtitles.py
@@ -66,16 +66,18 @@ class Subtitles(object):
         else:
             self.FORMATS['_default'] = 'vtt'
 
-        sub_lang = context.get_subtitle_language()
-        ui_lang = settings.get_language()
-        if not sub_lang and ui_lang:
-            self.preferred_lang = (ui_lang,)
-        elif sub_lang:
-            if (ui_lang and
-                    sub_lang.partition('-')[0] != ui_lang.partition('-')[0]):
-                self.preferred_lang = (sub_lang, ui_lang)
+        kodi_sub_lang = context.get_subtitle_language()
+        plugin_lang = settings.get_language()
+        if not kodi_sub_lang and plugin_lang:
+            self.preferred_lang = (plugin_lang,)
+        elif kodi_sub_lang:
+            if not plugin_lang:
+                self.preferred_lang = (kodi_sub_lang,)
+            elif (plugin_lang.partition('-')[0]
+                  != kodi_sub_lang.partition('-')[0]):
+                self.preferred_lang = (kodi_sub_lang, plugin_lang)
             else:
-                self.preferred_lang = (sub_lang,)
+                self.preferred_lang = (kodi_sub_lang,)
         else:
             self.preferred_lang = ('en',)
 

--- a/resources/lib/youtube_plugin/youtube/helper/yt_play.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_play.py
@@ -40,7 +40,7 @@ def play_video(provider, context):
 
     is_external = ui.get_property(SWITCH_PLAYER_FLAG)
     if ((is_external and settings.alternative_player_web_urls())
-            or (not is_external and settings.default_player_web_urls())):
+            or settings.default_player_web_urls()):
         video_stream = {
             'url': 'https://www.youtube.com/watch?v={0}'.format(video_id),
         }

--- a/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
@@ -322,7 +322,7 @@ def process_default_settings(_provider, context, step, steps):
         settings.use_mpd_videos(True)
         settings.stream_select(4 if settings.ask_for_video_quality() else 3)
         settings.set_subtitle_download(False)
-        settings.live_stream_type(2)
+        settings.live_stream_type(3)
         if not xbmcvfs.exists('special://profile/playercorefactory.xml'):
             settings.default_player_web_urls(False)
         if settings.cache_size() < 20:

--- a/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
@@ -373,7 +373,7 @@ def process_performance_settings(_provider, context, step, steps):
             },
             '1080p30_avc': {
                 'max_resolution': 4,  # 1080p
-                'stream_features': ('avc1', 'vorbis', 'mp4a', 'filter'),
+                'stream_features': ('avc1', 'vorbis', 'opus', 'mp4a', 'filter'),
                 'num_items': 10,
                 'settings': (
                     (settings.client_selection, (2,)),
@@ -381,32 +381,32 @@ def process_performance_settings(_provider, context, step, steps):
             },
             '1080p30': {
                 'max_resolution': 4,  # 1080p
-                'stream_features': ('avc1', 'vp9', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 20,
             },
             '1080p60': {
                 'max_resolution': 4,  # 1080p
-                'stream_features': ('avc1', 'vp9', 'hfr', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'hfr', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 30,
             },
             '4k30': {
                 'max_resolution': 6,  # 4k
-                'stream_features': ('avc1', 'vp9', 'hdr', 'hfr', 'no_hfr_max', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'hdr', 'hfr', 'no_hfr_max', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 50,
             },
             '4k60': {
                 'max_resolution': 6,  # 4k
-                'stream_features': ('avc1', 'vp9', 'hdr', 'hfr', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'hdr', 'hfr', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 50,
             },
             '4k60_av1': {
                 'max_resolution': 6,  # 4k
-                'stream_features': ('avc1', 'vp9', 'av01', 'hdr', 'hfr', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'av01', 'hdr', 'hfr', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 50,
             },
             'max': {
                 'max_resolution': 7,  # 8k
-                'stream_features': ('avc1', 'vp9', 'av01', 'hdr', 'hfr', 'vorbis', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
+                'stream_features': ('avc1', 'vp9', 'av01', 'hdr', 'hfr', 'vorbis', 'opus', 'mp4a', 'ssa', 'ac-3', 'ec-3', 'dts', 'filter'),
                 'num_items': 50,
             },
         }

--- a/resources/lib/youtube_plugin/youtube/provider.py
+++ b/resources/lib/youtube_plugin/youtube/provider.py
@@ -129,8 +129,8 @@ class Provider(AbstractProvider):
 
         items_per_page = settings.items_per_page()
 
-        language = settings.get_language()
-        region = settings.get_region()
+        plugin_lang = settings.get_language()
+        plugin_region = settings.get_region()
 
         api_last_origin = access_manager.get_last_origin()
 
@@ -220,8 +220,8 @@ class Provider(AbstractProvider):
                 context.log_debug('Access token count: |%d| Refresh token count: |%d|' % (len(access_tokens), len(refresh_tokens)))
 
         client = YouTube(context=context,
-                         language=language,
-                         region=region,
+                         language=plugin_lang,
+                         region=plugin_region,
                          items_per_page=items_per_page,
                          config=dev_keys if dev_keys else youtube_config)
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -115,12 +115,11 @@
                     <level>0</level>
                     <!--
                     All selections enabled except:
-                        - Opus audio
                         - no HFR at max quality
                         - no fractional framerate hinting
                         - no framerate hinting
                     -->
-                    <default>avc1,vp9,av01,hdr,hfr,vorbis,mp4a,ssa,ac-3,ec-3,dts,filter</default>
+                    <default>avc1,vp9,av01,hdr,hfr,vorbis,opus,mp4a,ssa,ac-3,ec-3,dts,filter</default>
                     <constraints>
                         <options>
                             <option label="30727">avc1</option>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -575,14 +575,12 @@
                 <setting id="kodion.support.alternative_player" type="boolean" label="30036" help="">
                     <level>0</level>
                     <default>false</default>
-                    <control type="toggle"/>
-                </setting>
-                <setting id="kodion.default_player.web_urls" type="boolean" parent="kodion.support.alternative_player" label="30704" help="">
-                    <level>0</level>
-                    <default>false</default>
                     <dependencies>
                         <dependency type="enable">
-                            <condition setting="kodion.support.alternative_player" operator="is">true</condition>
+                            <or>
+                                <condition setting="kodion.support.alternative_player" operator="is">true</condition>
+                                <condition setting="kodion.default_player.web_urls" operator="is">false</condition>
+                            </or>
                         </dependency>
                     </dependencies>
                     <control type="toggle"/>
@@ -595,7 +593,6 @@
                             <and>
                                 <condition setting="kodion.support.alternative_player" operator="is">true</condition>
                                 <condition setting="kodion.alternative_player.adaptive" operator="is">false</condition>
-                                <condition setting="kodion.default_player.web_urls" operator="is">false</condition>
                             </and>
                         </dependency>
                     </dependencies>
@@ -610,10 +607,19 @@
                                 <condition setting="kodion.support.alternative_player" operator="is">true</condition>
                                 <or>
                                     <condition setting="kodion.alternative_player.adaptive" operator="is">true</condition>
-                                    <condition setting="kodion.default_player.web_urls" operator="is">true</condition>
                                     <condition setting="kodion.alternative_player.web_urls" operator="is">false</condition>
                                 </or>
                             </and>
+                        </dependency>
+                    </dependencies>
+                    <control type="toggle"/>
+                </setting>
+                <setting id="kodion.default_player.web_urls" type="boolean" label="30704" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <dependencies>
+                        <dependency type="enable">
+                            <condition setting="kodion.support.alternative_player" operator="is">false</condition>
                         </dependency>
                     </dependencies>
                     <control type="toggle"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -665,7 +665,7 @@
                 </setting>
                 <setting id="kodion.live_stream.selection.1" type="integer" label="30689" help="30690">
                     <level>0</level>
-                    <default>2</default>  <!-- isa_hls -->
+                    <default>3</default>  <!-- isa_mpd -->
                     <constraints>
                         <options>
                             <option label="30740">0</option>  <!-- mpegts -->


### PR DESCRIPTION
## v7.0.6+beta.2
### Fixed
- Further fixes for multiple busy dialog crash workaround
  - Possibly fix issues reported in comments of #704
- Update error checks to avoid unnecessary retries of player requests

### Changed
- Make "Support alternative player" and "Use YouTube website urls with default player" mutually exclusive options #692
- Enable OPUS audio by default #537
- Enable MPEG-DASH for live streams by default #680
- Setup Wizard will prompt to run when plugin first opens after updating, in order to update default settings
- http server will shutdown on idle timeout #699