### PR TITLE
v7.0.6.3

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.6.2" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.6.3" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-## v7.0.6.2
+## v7.0.6.3
 ### Fixed
 - Improve updating containers and (re)loading windows #681
 - Fix refreshing video listing also forcing next pages to refresh when loaded
@@ -9,6 +9,7 @@
 - Update error checks to avoid unnecessary retries of player requests
 - Fix adding and viewing items to internal bookmarks and watchlater list #720
 - Fix error checks to prevent prematurely stopping retries of player requests #730
+- Disable using android client player request by default #737
 
 ### Changed
 - Setup Wizard default settings now disable pre-downloading subtitles if MPEG-DASH is enabled

--- a/resources/lib/youtube_plugin/youtube/client/request_client.py
+++ b/resources/lib/youtube_plugin/youtube/client/request_client.py
@@ -60,6 +60,7 @@ class YouTubeRequestClient(BaseRequestsClass):
         },
         'android': {
             '_id': 3,
+            '_disabled': True,
             '_query_subtitles': 'optional',
             'json': {
                 'context': {
@@ -343,11 +344,18 @@ class YouTubeRequestClient(BaseRequestsClass):
         return result
 
     @classmethod
-    def build_client(cls, client_name, data=None):
+    def build_client(cls, client_name=None, data=None):
         templates = {}
 
-        client = (cls.CLIENTS.get(client_name)
-                  or YouTubeRequestClient.CLIENTS['web']).copy()
+        client = None
+        if client_name:
+            client = cls.CLIENTS.get(client_name)
+            if client and client.get('_disabled'):
+                return None
+        if not client:
+            client = YouTubeRequestClient.CLIENTS['web']
+        client = client.copy()
+
         if data:
             client = merge_dicts(client, data)
         client = merge_dicts(cls.CLIENTS['_common'], client, templates)

--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -1166,6 +1166,8 @@ class VideoInfo(YouTubeRequestClient):
                         )
                     )
                 client = self.build_client(client_name, client_data)
+                if not client:
+                    continue
 
                 result = self.request(
                     video_info_url,
@@ -1420,6 +1422,8 @@ class VideoInfo(YouTubeRequestClient):
                     and subtitles.sub_selection == subtitles.LANG_ALL)):
             for client_name in ('smarttv_embedded', 'web', 'android'):
                 caption_client = self.build_client(client_name, client_data)
+                if not caption_client:
+                    continue
                 result = self.request(
                     video_info_url,
                     'POST',


### PR DESCRIPTION
## v7.0.6.3
### Fixed
- Improve updating containers and (re)loading windows #681
- Fix refreshing video listing also forcing next pages to refresh when loaded
- Fix overflow error resulting from parsing hashtags as episode numbers
- Fix 6s delay on video playback start
- Further fixes for multiple busy dialog crash workaround
  - Possibly fix issues reported in comments of #704
- Update error checks to avoid unnecessary retries of player requests
- Fix adding and viewing items to internal bookmarks and watchlater list #720
- Fix error checks to prevent prematurely stopping retries of player requests #730
- Disable using android client player request by default #737

### Changed
- Setup Wizard default settings now disable pre-downloading subtitles if MPEG-DASH is enabled
- Ask for quality, Play with subtitles, Play audio only context menu items only displayed if associated setting is not already enabled
- Only make extra request for subtitles for Android client when all subtitle languages are enabled
- Overhaul alternative player support due to Kodi changes and also improve external player support
- Make "Support alternative player" and "Use YouTube website urls with default player" mutually exclusive options #692
- Enable OPUS audio by default #537
- Enable MPEG-DASH for live streams by default #680
- Setup Wizard will prompt to run when plugin first opens after updating, in order to update default settings
- http server will shutdown on idle timeout #699
- Update client details used for player requests

### New
- Add recommended settings in Setup Wizard for Raspberry Pi 1/2 class devices #688
- Added Bookmarks
  - Save videos, channels, playlists to Bookmarks
  - Bookmarked channels will be checked for updates in My Subscriptions
  - Data is stored locally, without needing to be logged in