### PR TITLE
v7.0.8

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.0.8+beta.5" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.0.8" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,46 @@
+## v7.0.8
+### Fixed
+- Update selection and sorting of streams to fix missing live streams
+- Fix using cached settings for XbmcContext.use_inputstream_adaptive
+- Wakeup http server on playback start if required #746
+- Improve handling of context menu play items
+- Use consistent return values for function cache to avoid caching errors #782
+- Attempt to fix PlaylistPlayer race condition error #704
+- Fix not reloading access manager when performing user actions #780
+- Fix page jump when page_token is not used
+- Ensure container is always refreshed when required and available
+- Fix incorrect comparison after cd45122
+- Fix various caching issues #786 #797
+- Fix including un-redacted IP address in debug logs
+- Additional fixes for redacting IP addresses in debug logs #801
+- Various minor fixes for external player use
+- Fix trying to access playlists for account that has no Youtube channel #803
+- Poll for http server restart when required for playback #746 #808
+- Fix unsubscribe from My Subscriptions #809
+- Fix Python2 UnicodeDecodeError when removing/renaming searches #815
+- Fix not catching socket.error in Python2 when force shutting down socket
+- Fix deleting window property with multiple threads causing hang on exit #813
+
+### Changed
+- Update icons
+- Only enable recommendations when logged in
+- Improve sync with internal Kodi watched state #709
+- Align default value for watched percentage with Kodi default #746
+- Limit need to check window property for sleep and wakeup
+- Only show Next Page listitem linking to first page when in the GUI #787
+- Use youtu.be urls with external players to work with different types of videos
+- Test not starting/checking for http server until required for playback #746
+- Invalidate portion of playlist cache if item added to playlist #797
+- Update 720p preset in Setup Wizard #807
+- Update itags found in HLS playlists and exclude them in quality selection #806
+
+### New
+- Cache and update My Subscriptions content per channel feed #785 #786
+- Use separate database for My Subscription feed history #785
+- Enable action parameter in play playlist route
+- Use placeholder in empty listings to provide info and allow refreshing #797
+- Enable subtitles for alternative client 2 #806
+
 ## v7.0.8+beta.5
 ### Fixed
 - Fix Python2 UnicodeDecodeError when removing/renaming searches #815


### PR DESCRIPTION
### Fixed
- Update selection and sorting of streams to fix missing live streams
- Fix using cached settings for XbmcContext.use_inputstream_adaptive
- Wakeup http server on playback start if required #746
- Improve handling of context menu play items
- Use consistent return values for function cache to avoid caching errors #782
- Attempt to fix PlaylistPlayer race condition error #704
- Fix not reloading access manager when performing user actions #780
- Fix page jump when page_token is not used
- Ensure container is always refreshed when required and available
- Fix incorrect comparison after cd45122
- Fix various caching issues #786 #797
- Fix including un-redacted IP address in debug logs
- Additional fixes for redacting IP addresses in debug logs #801
- Various minor fixes for external player use
- Fix trying to access playlists for account that has no Youtube channel #803
- Poll for http server restart when required for playback #746 #808
- Fix unsubscribe from My Subscriptions #809
- Fix Python2 UnicodeDecodeError when removing/renaming searches #815
- Fix not catching socket.error in Python2 when force shutting down socket
- Fix deleting window property with multiple threads causing hang on exit #813

### Changed
- Update icons
- Only enable recommendations when logged in
- Improve sync with internal Kodi watched state #709
- Align default value for watched percentage with Kodi default #746
- Limit need to check window property for sleep and wakeup
- Only show Next Page listitem linking to first page when in the GUI #787
- Use youtu.be urls with external players to work with different types of videos
- Test not starting/checking for http server until required for playback #746
- Invalidate portion of playlist cache if item added to playlist #797
- Update 720p preset in Setup Wizard #807
- Update itags found in HLS playlists and exclude them in quality selection #806

### New
- Cache and update My Subscriptions content per channel feed #785 #786
- Use separate database for My Subscription feed history #785
- Enable action parameter in play playlist route
- Use placeholder in empty listings to provide info and allow refreshing #797
- Enable subtitles for alternative client 2 #806