### PR TITLE
v7.1.1.4

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.1.1.3" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.1.1.4" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-## v7.1.1.3
+## v7.1.1.4
 ### Fixed
 - Fix http server not listening on any interface if listen IP is 0.0.0.0 #927
 - Standardise return type of LoginClient.refresh_token #932
@@ -40,6 +40,8 @@
 - Fix missing "Ask" translation string
 - Fix incorrect parameter name breaking auto-remove from Watch Later #993
 - Fix processing of "q" and "channelId" search query params #1004
+- Fix errors with progress dialogs in Kodi 18 #1000
+- Fix remote watch history not updating #1008
 
 ### Changed
 - Improve display and update of bookmarks

--- a/resources/lib/youtube_plugin/kodion/ui/abstract_progress_dialog.py
+++ b/resources/lib/youtube_plugin/kodion/ui/abstract_progress_dialog.py
@@ -87,10 +87,9 @@ class AbstractProgressDialog(object):
             message = self._message_template.format(**self._template_params)
             self._message = message
 
-        self._dialog.update(
-            percent=position,
-            message=message,
-        )
+        # Kodi 18 renamed XbmcProgressDialog.update argument line1 to message.
+        # Only use positional arguments to maintain compatibility
+        self._dialog.update(position, self._message)
 
     def is_aborted(self):
         raise NotImplementedError()

--- a/resources/lib/youtube_plugin/youtube/client/request_client.py
+++ b/resources/lib/youtube_plugin/youtube/client/request_client.py
@@ -172,6 +172,7 @@ class YouTubeRequestClient(BaseRequestsClass):
         },
         'ios': {
             '_id': 5,
+            '_auth_type': False,
             '_os': {
                 'major': '17',
                 'minor': '5',
@@ -261,6 +262,7 @@ class YouTubeRequestClient(BaseRequestsClass):
         },
         '_common': {
             '_access_token': None,
+            '_access_token_tv': None,
             'json': {
                 'contentCheckOk': True,
                 'context': {
@@ -286,13 +288,11 @@ class YouTubeRequestClient(BaseRequestsClass):
                 'videoId': None,
             },
             'headers': {
-                'Origin': 'https://www.youtube.com',
-                'Referer': 'https://www.youtube.com/watch?v={json[videoId]}',
                 'Accept-Encoding': 'gzip, deflate',
                 'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
                 'Accept': '*/*',
                 'Accept-Language': 'en-US,en;q=0.5',
-                'Authorization': 'Bearer {_access_token}',
+                'Authorization': None,
             },
             'params': {
                 'key': ValueError,
@@ -369,31 +369,53 @@ class YouTubeRequestClient(BaseRequestsClass):
     def build_client(cls, client_name=None, data=None):
         templates = {}
 
-        client = None
+        base_client = None
         if client_name:
-            client = cls.CLIENTS.get(client_name)
-            if client and client.get('_disabled'):
+            base_client = cls.CLIENTS.get(client_name)
+            if base_client and base_client.get('_disabled'):
                 return None
-        if not client:
-            client = YouTubeRequestClient.CLIENTS['web']
-        client = client.copy()
+        if not base_client:
+            base_client = YouTubeRequestClient.CLIENTS['web']
+        base_client = base_client.copy()
 
         if data:
-            client = merge_dicts(client, data)
+            client = merge_dicts(base_client, data)
         client = merge_dicts(cls.CLIENTS['_common'], client, templates)
         client['_name'] = client_name
+        if base_client.get('_auth_required'):
+            client['_auth_required'] = True
 
         for values, template_id, template in templates.values():
             if template_id in values:
                 values[template_id] = template.format(**client)
 
+        has_auth = False
         try:
             params = client['params']
-            if client.get('_access_token'):
+            auth_required = client.get('_auth_required')
+            auth_requested = client.get('_auth_requested')
+            auth_type = client.get('_auth_type')
+            if auth_type == 'tv' and auth_requested != 'personal':
+                auth_token = client.get('_access_token_tv')
+            elif auth_type is not False:
+                auth_token = client.get('_access_token')
+            else:
+                auth_token = None
+
+            if auth_token and (auth_required or auth_requested):
+                headers = client['headers']
+                if 'Authorization' in headers:
+                    headers = headers.copy()
+                    headers['Authorization'] = 'Bearer {0}'.format(auth_token)
+                    client['headers'] = headers
+                    has_auth = True
+
                 if 'key' in params:
                     params = params.copy()
                     del params['key']
                     client['params'] = params
+            elif auth_required:
+                return None
             else:
                 headers = client['headers']
                 if 'Authorization' in headers:
@@ -407,5 +429,6 @@ class YouTubeRequestClient(BaseRequestsClass):
                     client['params'] = params
         except KeyError:
             pass
+        client['_has_auth'] = has_auth
 
         return client

--- a/resources/lib/youtube_plugin/youtube/client/youtube.py
+++ b/resources/lib/youtube_plugin/youtube/client/youtube.py
@@ -85,6 +85,24 @@ class YouTube(LoginClient):
                 'Host': 'www.youtube.com',
             },
         },
+        'watch_history': {
+            '_auth_required': True,
+            '_auth_type': 'personal',
+            '_video_id': None,
+            'headers': {
+                'Host': 's.youtube.com',
+                'Referer': 'https://www.youtube.com/watch?v={_video_id}',
+            },
+            'params': {
+                'referrer': 'https://accounts.google.com/',
+                'ns': 'yt',
+                'el': 'detailpage',
+                'ver': '2',
+                'fs': '0',
+                'volume': '100',
+                'muted': '0',
+            },
+        },
         '_common': {
             '_access_token': None,
             '_access_token_tv': None,
@@ -155,29 +173,13 @@ class YouTube(LoginClient):
                                   et=et,
                                   state=state))
 
-        headers = {
-            'Host': 's.youtube.com',
-            'Connection': 'keep-alive',
-            'Accept-Encoding': 'gzip, deflate',
-            'Accept-Charset': 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
-            'Accept': '*/*',
-            'Accept-Language': 'en-US,en;q=0.5',
-            'DNT': '1',
-            'Referer': 'https://www.youtube.com/watch?v=' + video_id,
-            'User-Agent': ('Mozilla/5.0 (Linux; Android 10; SM-G981B)'
-                           ' AppleWebKit/537.36 (KHTML, like Gecko)'
-                           ' Chrome/80.0.3987.162 Mobile Safari/537.36'),
+        client_data = {
+            '_video_id': video_id,
+            'url': url,
+            'error_title': 'Failed to update watch history',
         }
-        params = {
-            'docid': video_id,
-            'referrer': 'https://accounts.google.com/',
-            'ns': 'yt',
-            'el': 'detailpage',
-            'ver': '2',
-            'fs': '0',
-            'volume': '100',
-            'muted': '0',
-        }
+
+        params = {}
         if cmt is not None:
             params['cmt'] = format(cmt, '.3f')
         if st is not None:
@@ -186,11 +188,11 @@ class YouTube(LoginClient):
             params['et'] = format(et, '.3f')
         if state is not None:
             params['state'] = state
-        if self._access_token:
-            params['access_token'] = self._access_token
 
-        self.request(url, params=params, headers=headers,
-                     error_msg='Failed to update watch history')
+        self.api_request(client='watch_history',
+                         client_data=client_data,
+                         params=params,
+                         no_content=True)
 
     def get_streams(self,
                     context,

--- a/resources/lib/youtube_plugin/youtube/helper/stream_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/stream_info.py
@@ -703,7 +703,8 @@ class StreamInfo(YouTubeRequestClient):
         self._calculate_n = True
         self._cipher = None
 
-        self._selected_client = None
+        self._auth_client = {}
+        self._selected_client = {}
         self._client_groups = {
             'custom': clients if clients else (),
             # Access "premium" streams, HLS and DASH
@@ -1357,6 +1358,7 @@ class StreamInfo(YouTubeRequestClient):
         audio_only = self._audio_only
         ask_for_quality = self._ask_for_quality
         use_mpd = self._use_mpd
+        use_remote_history = settings.use_remote_history()
 
         client_name = None
         _client = None
@@ -1394,19 +1396,23 @@ class StreamInfo(YouTubeRequestClient):
         }
         abort = False
 
-        client_data = {'json': {'videoId': video_id}}
-        access_token = self._access_token
-        auth = False
+        has_access_token = bool(self._access_token)
+        client_data = {
+            'json': {
+                'videoId': video_id,
+            },
+            '_auth_required': False,
+            '_auth_requested': 'personal' if use_remote_history else False,
+            '_access_token': self._access_token,
+        }
 
         for name, clients in self._client_groups.items():
             if not clients:
                 continue
-            if name == 'mpd' and not use_mpd:
+            if name == 'mpd' and not (use_mpd or use_remote_history):
                 continue
             if name == 'ask' and use_mpd and not ask_for_quality:
                 continue
-
-            status = None
 
             restart = False
             while 1:
@@ -1424,7 +1430,7 @@ class StreamInfo(YouTubeRequestClient):
                         error_hook_kwargs={
                             'video_id': video_id,
                             'client': client_name,
-                            'auth': bool(_client.get('_access_token')),
+                            'auth': _client.get('_has_auth', False),
                         },
                         **_client
                     ) or {}
@@ -1469,14 +1475,13 @@ class StreamInfo(YouTubeRequestClient):
                                 reason=reason or 'UNKNOWN',
                                 video_id=video_id,
                                 client=_client['_name'],
-                                auth=auth,
+                                auth=_client.get('_has_auth', False),
                             )
                         )
                         compare_reason = reason.lower()
                         if any(why in compare_reason for why in reauth_reasons):
-                            if access_token and not auth:
-                                auth = True
-                                client_data['_access_token'] = access_token
+                            if has_access_token:
+                                client_data['_auth_required'] = True
                                 restart = True
                             break
                         if any(why in compare_reason for why in retry_reasons):
@@ -1510,14 +1515,19 @@ class StreamInfo(YouTubeRequestClient):
                     .format(
                         video_id=video_id,
                         client=client_name,
-                        auth=bool(_client.get('_access_token')),
+                        auth=_client.get('_has_auth', False),
                     )
                 )
                 if not self._selected_client:
-                    client = self._selected_client = _client.copy()
-                    result = _result
-                    video_details = result.get('videoDetails', {})
-                    playability = result.get('playabilityStatus', {})
+                    self._selected_client = {
+                        'client': _client.copy(),
+                        'result': _result,
+                    }
+                if not self._auth_client and _client.get('_has_auth'):
+                    self._auth_client = {
+                        'client': _client.copy(),
+                        'result': _result,
+                    }
 
                 _streaming_data = _result.get('streamingData', {})
                 if audio_only or ask_for_quality or not use_mpd:
@@ -1549,6 +1559,9 @@ class StreamInfo(YouTubeRequestClient):
                 reason = self._get_error_details(playability)
             raise YouTubeException(reason or 'UNKNOWN')
 
+        client = self._selected_client['client']
+        result = self._selected_client['result']
+
         if 'Authorization' in client['headers']:
             del client['headers']['Authorization']
         # Make a set of URL-quoted headers to be sent to Kodi when requesting
@@ -1557,8 +1570,7 @@ class StreamInfo(YouTubeRequestClient):
         # curl_headers = self._make_curl_headers(headers, cookies)
         curl_headers = self._prepare_headers(client['headers'])
 
-        microformat = (result.get('microformat', {})
-                       .get('playerMicroformatRenderer', {}))
+        video_details = result.get('videoDetails', {})
         is_live = video_details.get('isLiveContent', False)
         if is_live:
             is_live = video_details.get('isLive', False)
@@ -1568,6 +1580,8 @@ class StreamInfo(YouTubeRequestClient):
             live_dvr = False
             thumb_suffix = ''
 
+        microformat = (result.get('microformat', {})
+                       .get('playerMicroformatRenderer', {}))
         meta_info = {
             'id': video_id,
             'title': unescape(video_details.get('title', '')
@@ -1597,12 +1611,14 @@ class StreamInfo(YouTubeRequestClient):
             'subtitles': None,
         }
 
-        if settings.use_remote_history():
+        if use_remote_history and self._auth_client:
             playback_stats = {
                 'playback_url': 'videostatsPlaybackUrl',
                 'watchtime_url': 'videostatsWatchtimeUrl',
             }
-            playback_tracking = result.get('playbackTracking', {})
+            playback_tracking = (self._auth_client
+                                 .get('result', {})
+                                 .get('playbackTracking', {}))
             cpn = self._generate_cpn()
 
             for key, url_key in playback_stats.items():
@@ -1637,7 +1653,7 @@ class StreamInfo(YouTubeRequestClient):
                     '',
                     '',
                 )) + '||R{{SSM}}|R',
-                'token': access_token,
+                'token': self._access_token,
             }
             break
         else:
@@ -1699,7 +1715,7 @@ class StreamInfo(YouTubeRequestClient):
                     error_hook_kwargs={
                         'video_id': video_id,
                         'client': client_name,
-                        'auth': bool(caption_client.get('_access_token')),
+                        'auth': _client.get('_has_auth', False),
                     },
                     **caption_client
                 )


### PR DESCRIPTION
### Fixed
- Fix http server not listening on any interface if listen IP is 0.0.0.0 #927
- Standardise return type of LoginClient.refresh_token #932
- Fix curl headers not being used when set on path of setResolvedUrl listitem
- Fix HEAD requests to MPD manifests
- Fix various Python2 incompatible changes
- Properly distinguish between VP9 and VP9.2 with HDR info
- Fix http server not running when script shows client IP
- Fix not listing full stream details in selection dialog
- Fix translated subtitles not being available for some videos #945
- Fix labelling for auto dubbed audio tracks
- Fix regressions in handling VP9.2 video streams
- Fix error handling items without headers #946
- Fix incorrectly determining Kodi release name
- Fix search window history navigation when using direct links
- Fix Python2/Android incompatibilty when checking CPU count #958
- Fix method used to determine address of local network interface #938
- Fix potential infinite loop with corrupted access_manager.json
- Various improvements to multiple busy dialog crash workarounds #938
- Fallback to search listing when search query is empty
- Fix debug log string formatting error #938
- Fix duplicated separators in context menu
- Fix Kodi builtin using wrong playlist type #938
- Ensure http server is started prior to creating MPD for playback #961
- Fix shuffle play of playlists not working
- Fix plugin category label not being applied if content type not set
- Fix Kodi navigating to root path of Video window if plugin listing fails
- Fix loading of Watch Later playlist #971
 - Also fix other incorrect/missing parameter names
- Fix possible exception if plugin navigation fails #976
- Fix sign in when one or more access token requests fail #979
- Attempt to fix possible deadlock on http server shutdown
- Fix potential infinite loop with old data from access_manager.json #980
- Reduce unnecessary window navigation fallback attempts
- Fix incorrect duration display in Kodi 18 and Kodi 19 #999
- Fix possible error with getting names of bookmarks that have not been updated with info
- Fix missing "Live" label in Kodi 18
- Fix uncaught exception when sign-in does not succeed #985
- Fix missing "Ask" translation string
- Fix incorrect parameter name breaking auto-remove from Watch Later #993
- Fix processing of "q" and "channelId" search query params #1004
- Fix errors with progress dialogs in Kodi 18 #1000
- Fix remote watch history not updating #1008

### Changed
- Improve display and update of bookmarks
- Explicitly set http server protocol version to HTTP/1.1
- Improve logging
- Use alternative streams to improve compatibility with external players
- Improve https server sleep and wakeup #810 #951
- Update Setup Wizard to disable all alternative player settings if not required #938
- Improve support for optional search API parameters #689
- Ensure changing sort order of search replaces existing search
- Use redirect in multiple busy dialog crash workaround #938
- Disable unusable alternate players #966
- Standardise plugin URIs for routing
  - path parameters used for folders and sub-folders
  - query parameters used for changing display modes, filtering, sorting and inputs
- Don't retry server wakeup on error unless settings change
- Allow ISA and MPD in 720p performance preset in Setup Wizard
- Only use OAuth tokens if necessary #994 #996

### New
- Explicitly enable TCP keep alive #913
- Add localised title and description for videos, channels and playlists
- Update display of playlists to show the following details:
  - item count
  - date
  - channel name
  - description
  - web url
  - podcast status
- Update display of channels to show the following details:
  - view count
  - subscriber count
  - video count
  - date
  - description
  - channel name in description
  - web url
- Add View all and Shuffle context menu items for playlists
- New setting to enable debug logging for addon
  - Setting > Advanced > Logging > Enable debug logging
- Improvements to searching
  - Add context menu items for changing sort order of saved searches #172
  - Allow search parameters to be stored per search #172 #689
  - Allow additional optional search parameters to be used #689
  - Improve parsing of date offset when searching  for completed live events
- Add additional search type links to search results #689
- Add ability to replace window when rerouting using window_replace query parameter
- Add search sort context menu items to search results #172
- Add prompts and notifications for deleting items and clearing lists
- Add Quick Search and search management context menu items to Search folders
- Add context menu items to Clear and Play All/Shuffle in Bookmarks/Watch Later/Watch History folders
- Add progress dialog to My Subscription loading