### PR TITLE
Update addon checker workflow

### DIFF
--- a/.github/workflows/addon-validations.yml
+++ b/.github/workflows/addon-validations.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.x' ]
+        python-version: [ '3.12' ]
 
     steps:
       - name: Checkout Add-on


### PR DESCRIPTION
Pin Addon Checker workflow Python verion to v3.12

- Hotfix until Addon Checker is updated to fix issues with deprecated lib2to3 in Python v3.13