### PR TITLE
POC: Page item offset for filtered lists

### DIFF
--- a/resources/lib/youtube_plugin/kodion/sql_store/feed_history.py
+++ b/resources/lib/youtube_plugin/kodion/sql_store/feed_history.py
@@ -27,9 +27,12 @@ class FeedHistory(Storage):
                                   values_only=False)
         return result
 
-    def get_item(self, content_id, seconds=None):
-        result = self._get(content_id, seconds=seconds, as_dict=True)
+    def get_item(self, content_id, seconds=None, as_dict=True):
+        result = self._get(content_id, seconds=seconds, as_dict=as_dict)
         return result
+
+    def set_item(self, content_id, item):
+        self._set(content_id, item)
 
     def set_items(self, items):
         self._set_many(items)


### PR DESCRIPTION
Current logic will fill a page with filtered items from one or more pages up to the configured page size, and when the page is full the remaining items are discarded and the next page counter is incremented, which results in the discarded items being skipped over between pages.

This is a proof of concept (because I'm not experienced with Kodi plugin dev and not sure if this is the best way to go about this) to cache the first page offset when paginating filtered lists. Rather than incrementing the next page counter, if there are any discarded items by the time the page is filled the latest remainder amount is cached as an offset value against that page and path, and the next page counter is _not_ incremented. When the next page is requested by the user, the cache is checked for a value (with a TTL of one hour) and if it exists, the first n items on the page equal to the offset are skipped (assumed to have been read on the previous page).