### PR TITLE
Fix exception when `locale.language` is `None`

### DIFF
--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -574,7 +574,8 @@ class XbmcContext(AbstractContext):
         language = get_kodi_setting_value('locale.subtitlelanguage')
         if language == 'default':
             language = get_kodi_setting_value('locale.language')
-            language = language.replace('resource.language.', '').split('_')[0]
+            if language != None:
+                language = language.replace('resource.language.', '').split('_')[0]
         elif language in self._KODI_UI_SUBTITLE_LANGUAGE_OPTIONS:
             language = None
         else:


### PR DESCRIPTION
This change fix this error:
```
2026-01-17 09:46:54.590 T:7495    error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: 'NoneType' object has no attribute 'replace'
                                                   Traceback (most recent call last):
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/plugin.py", line 16, in <module>
                                                       plugin_runner.run()
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/plugin_runner.py", line 132, in run
                                                       plugin.run(provider,
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py", line 209, in run
                                                       result, options = provider.navigate(context)
                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/abstract_provider.py", line 203, in navigate
                                                       result = handler(provider=self, context=context, re_match=re_match)
                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/youtube/helper/yt_play.py", line 556, in process
                                                       media_item = _play_stream(provider, context)
                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/youtube/helper/yt_play.py", line 85, in _play_stream
                                                       streams, yt_item = client.load_stream_info(
                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/youtube/client/player_client.py", line 2004, in load_stream_info
                                                       subtitles = Subtitles(context, video_id, use_mpd=use_mpd)
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/youtube/client/subtitles.py", line 134, in __init__
                                                       kodi_sub_lang = context.get_subtitle_language()
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                     File "/storage/emulated/0/Android/data/org.xbmc.kodi/files/.kodi/addons/plugin.video.youtube/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py", line 577, in get_subtitle_language
                                                       language = language.replace('resource.language.', '').split('_')[0]
                                                                  ^^^^^^^^^^^^^^^^
                                                   AttributeError: 'NoneType' object has no attribute 'replace'
                                                   -->End of Python script error report<--
```

Not sure if this is caused by some configuration issue on my install of kodi, but in any case it seems reasonable to check for that.