### PR TITLE
v7.4.1+beta.2

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.4.1+beta.1" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.4.1+beta.2" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+## v7.4.1+beta.2
+### Fixed
+- Fix unnecessary double resolve on playback #1371
+- Attempt to break busy dialog workaround loop if post run action succeeds #1386
+- Don't swallow unhandled plugin exceptions without logging and running listing end callback #1386
+- Python 2 compatibility fix for urllib3 only checking for str type when accessing module constants using getattr
+
 ## v7.4.1+beta.1
 ### Fixed
 - Always refresh missing access tokens if partially logged in and refresh tokens are available #1389

--- a/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
@@ -456,7 +456,12 @@ def playback_item(context, media_item, show_fanart=None, **_kwargs):
         }
         props = {
             'isPlayable': VALUE_TO_STR[media_item.playable],
-            'ForceResolvePlugin': 'true',
+            # ForceResolvePlugin was broken in Kodi v21+ after being added in
+            # Kodi v20.
+            # Set to false and use other workarounds as listitem is otherwise
+            # resolved twice when using PlayMedia, Player.Open, etc. leading to
+            # crashes or busy dialog workaround loops in Kodi 20.
+            'ForceResolvePlugin': 'false',
             'playlist_type_hint': (
                 xbmc.PLAYLIST_MUSIC
                 if isinstance(media_item, AudioItem) else

--- a/resources/lib/youtube_plugin/kodion/network/requests.py
+++ b/resources/lib/youtube_plugin/kodion/network/requests.py
@@ -76,10 +76,10 @@ class SSLHTTPAdapter(HTTPAdapter):
     def cert_verify(self, conn, url, verify, cert):
         if verify:
             self._SSL_CONTEXT.check_hostname = True
-            conn.cert_reqs = 'CERT_REQUIRED'
+            conn.cert_reqs = str('CERT_REQUIRED')
         else:
             self._SSL_CONTEXT.check_hostname = False
-            conn.cert_reqs = 'CERT_NONE'
+            conn.cert_reqs = str('CERT_NONE')
         conn.ca_certs = None
         conn.ca_cert_dir = None
 

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -451,6 +451,7 @@ class XbmcPlugin(AbstractPlugin):
     def post_run(context, ui, *actions, **kwargs):
         timeout = kwargs.get('timeout', 30)
         interval = kwargs.get('interval', 0.1)
+        busy = True
         for action in actions:
             while not ui.get_container(container_type=False, check_ready=True):
                 timeout -= interval
@@ -460,6 +461,8 @@ class XbmcPlugin(AbstractPlugin):
                     break
                 context.sleep(interval)
             else:
+                if busy:
+                    busy = ui.clear_property(BUSY_FLAG)
                 if isinstance(action, tuple):
                     action, action_kwargs = action
                 else:

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -78,6 +78,15 @@ class XbmcPlugin(AbstractPlugin):
     def __init__(self):
         super(XbmcPlugin, self).__init__()
 
+    @staticmethod
+    def end(handle, succeeded=True, update_listing=False, cache_to_disc=True):
+        xbmcplugin.endOfDirectory(
+            handle=handle,
+            succeeded=succeeded,
+            updateListing=update_listing,
+            cacheToDisc=cache_to_disc,
+        )
+
     def run(self,
             provider,
             context,

--- a/resources/lib/youtube_plugin/kodion/plugin_runner.py
+++ b/resources/lib/youtube_plugin/kodion/plugin_runner.py
@@ -133,10 +133,17 @@ def run(context=_context,
                    is_same_path=is_same_path,
                    **new_kwargs)
     except Exception:
+        log.exception('Error')
         ui.clear_property(BUSY_FLAG)
         ui.clear_property(TRAKT_PAUSE_FLAG, raw=True)
         for param in FORCE_PLAY_PARAMS:
             ui.clear_property(param)
+        plugin.end(
+            context.get_handle(),
+            succeeded=False,
+            update_listing=True,
+            cache_to_disc=False,
+        )
     finally:
         if log_level:
             profiler.print_stats()


### PR DESCRIPTION
### Fixed
- Fix unnecessary double resolve on playback #1371
- Attempt to break busy dialog workaround loop if post run action succeeds #1386
- Don't swallow unhandled plugin exceptions without logging and running listing end callback #1386
- Python 2 compatibility fix for urllib3 only checking for str type when accessing module constants using getattr