### PR TITLE
Update bug report template for debug log requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,7 +51,11 @@ Please provide detailed steps for reproducing the issue.
 
 ### Log
 
-Nothing can or will be done about your issue report without a complete **debug** log. It is not enough to include an excerpt of the ordinary kodi log. Details on how a debug log can be produced are available on the Kodi Wiki: https://kodi.wiki/view/Log_file.
+Nothing can or will be done about your issue report without a complete **debug** log.
+
+It is not enough to include an excerpt of the ordinary Kodi event log.
+
+Details on how a debug log can be produced are available on the Kodi Wiki: https://kodi.wiki/view/Log_file.
 
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,7 +51,7 @@ Please provide detailed steps for reproducing the issue.
 
 ### Log
 
-Please include a complete [debug log](https://kodi.wiki/view/Log_file).
+Nothing can or will be done about your issue report without a complete **debug** log. It is not enough to include an excerpt of the ordinary kodi log. Details on how a debug log can be produced are available on the Kodi Wiki: https://kodi.wiki/view/Log_file.
 
 
 


### PR DESCRIPTION
Clarified the requirement for a complete debug log in the bug report template.

You get the idea. It's my optimistic approach to make clearer what kind of log is required (although debug log was already hyperlinked explicitly).