### PR TITLE
fix: prevent PLAY_FORCED false positive for /uri2addon/ playback

### DIFF
--- a/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
@@ -137,22 +137,19 @@ class ServiceMonitor(xbmc.Monitor):
 
                 if context.is_plugin_path(item_uri):
                     path, params = context.parse_uri(item_uri)
-                    if path.rstrip('/') != PATHS.PLAY:
+                    stripped_path = path.rstrip('/')
+
+                    if stripped_path == PATHS.PLAY:
+                        self.log.debug('Playlist.OnAdd item is a direct play command. Path: {path}', path=path)
+                    elif stripped_path == '/uri2addon':
+                        self.log.debug('Playlist.OnAdd item is a URI resolver request. Skipping PLAY_FORCED. Path: {path}', path=path)
+                    else:
                         self.log.warning(('Playlist.OnAdd item is not playable',
                                           'Path:   {path}',
                                           'Params: {params}'),
                                          path=path,
                                          params=params)
                         context.get_ui().set_property(PLAY_FORCED)
-                    elif params.get(ACTION) == 'list':
-                        playlist_player.stop()
-                        playlist_player.clear()
-                        self.log.warning(('Playlist.OnAdd item is a listing',
-                                          'Path:   {path}',
-                                          'Params: {params}'),
-                                         path=path,
-                                         params=params)
-                        context.get_ui().set_property(PLAY_CANCELLED)
 
             return
 

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -411,8 +411,9 @@ class XbmcPlugin(AbstractPlugin):
                 _post_run_action = None
 
         if ui.pop_property(PLAY_FORCED):
-            context.set_path(PATHS.PLAY)
-            return self.run(provider, context, forced=forced)
+            if force_resolve:
+                # Playback already resolved via setResolvedUrl — skip re-run
+                logging.warning('PLAY_FORCED was set but playback already resolved via force_resolve. Skipping re-run.')
 
         xbmcplugin.endOfDirectory(
             handle,


### PR DESCRIPTION
### Problem
When external apps (e.g., Kore) send YouTube Shorts URLs to Kodi, the plugin's service monitor incorrectly flags the `/uri2addon/` routing path as an unplayable directory and sets `PLAY_FORCED`. This triggers a chain reaction:
1. **`service_monitor.py`** sees `/uri2addon/` in `Playlist.OnAdd`, checks `path != PATHS.PLAY`, and sets `PLAY_FORCED`, and this condition: `params.get(ACTION) == 'list':` not trigger when its a playlist
2. **`xbmc_plugin.py`** resolves the Shorts URL via `on_uri2addon` → `FORCE_RESOLVE` → `setResolvedUrl` — video starts playing successfully
3. **Double execution** — immediately after, `PLAY_FORCED` triggers `self.run()` again, but the second run has no valid video ID and falls through to a fallback `Action(Back)`

### Fix
**`service_monitor.py`** — Whitelist `/uri2addon` alongside `/play` so it doesn't trigger `PLAY_FORCED`. The `/uri2addon/` handler is a single-item resolver that always outputs a playable `VideoItem` via `FORCE_RESOLVE`
**`xbmc_plugin.py`** — Guard the `PLAY_FORCED` re-run check with `force_resolve`. When `setResolvedUrl` has already been called (indicated by `force_resolve` being truthy), skip the recursive `self.run()` since playback is already in progress.
### Testing
-  Tested with YouTube Shorts, Single video, Playlist via Kore, LibreELEC (Raspberry Pi 4), debug mode on
