### PR TITLE
v7.4.2+beta.1

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.4.1.1" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.4.2+beta.1" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,22 @@
+## v7.4.2+beta.1
+### Fixed
+- Skip unplayable live manifests #1377
+- Handle inconsistent error codes and names used in Python 2 #1412
+- Simplify byte range to timestamp conversion for compatibility with Python 2 #1412
+- Fix unnecessarily reloading listing when adding items to Bookmarks
+
+### Changed
+- Rework addon debug log settings (Addon > Settings > Advanced > Debug > Enable debug logging) #1385
+  - Allowable values:
+    - Disabled (addon logging output disabled)
+    - Auto (default, addon logging output enabled if Kodi debug logging enabled)
+    - Always enabled (addon logging output enabled)
+    - Verbose (additional addon logging output enabled)
+- Various other improvement to addon logging
+
+### New
+- Update Setup Wizard to account for user possibly using mismatched watch history settings
+
 ## v7.4.1.1
 ### Fixed
 - Address possible race condition resulting in KeyError exception when calling pop() on an empty set

--- a/resources/lib/youtube_plugin/kodion/context/abstract_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/abstract_context.py
@@ -709,7 +709,12 @@ class AbstractContext(object):
     def tear_down(self):
         pass
 
-    def ipc_exec(self, target, timeout=None, payload=None, raise_exc=False):
+    def ipc_exec(self,
+                 target,
+                 timeout=None,
+                 payload=None,
+                 raise_exc=False,
+                 stacklevel=2):
         raise NotImplementedError()
 
     def is_plugin_folder(self, folder_name=None):

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -32,6 +32,7 @@ from ...constants import (
     CHANNEL_ID,
     CONTENT,
     FOLDER_NAME,
+    FOLDER_URI,
     PLAYLIST_ID,
     PLAY_FORCE_AUDIO,
     SERVICE_IPC,
@@ -1083,11 +1084,19 @@ class XbmcContext(AbstractContext):
             )
         return value
 
-    def is_plugin_folder(self, folder_name=None):
-        if folder_name is None:
-            folder_name = XbmcContextUI.get_container_info(FOLDER_NAME,
-                                                           container_id=None)
-        return folder_name == self._plugin_name
+    def is_plugin_folder(self, folder_path='', name=False):
+        if name:
+            return XbmcContextUI.get_container_info(
+                FOLDER_NAME,
+                container_id=None,
+            ) == self._plugin_name
+        return self.is_plugin_path(
+            XbmcContextUI.get_container_info(
+                FOLDER_URI,
+                container_id=None,
+            ),
+            folder_path,
+        )
 
     def refresh_requested(self, force=False, on=False, off=False, params=None):
         if params is None:

--- a/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
+++ b/resources/lib/youtube_plugin/kodion/context/xbmc/xbmc_context.py
@@ -1025,13 +1025,18 @@ class XbmcContext(AbstractContext):
             except AttributeError:
                 pass
 
-    def ipc_exec(self, target, timeout=None, payload=None, raise_exc=False):
+    def ipc_exec(self,
+                 target,
+                 timeout=None,
+                 payload=None,
+                 raise_exc=False,
+                 stacklevel=2):
         if not XbmcContextUI.get_property(SERVICE_RUNNING_FLAG, as_bool=True):
             msg = 'Service IPC - Monitor has not started'
             XbmcContextUI.set_property(SERVICE_RUNNING_FLAG, BUSY_FLAG)
             if raise_exc:
                 raise RuntimeError(msg)
-            self.log.warning_trace(msg)
+            self.log.warning_trace(msg, stacklevel=stacklevel)
             return None
 
         data = {'target': target, 'response_required': bool(timeout)}
@@ -1047,25 +1052,35 @@ class XbmcContext(AbstractContext):
         response = IPCMonitor(target, timeout)
         if response.received:
             value = response.value
-            if value:
-                self.log.debug(('Service IPC - Responded',
-                                'Procedure: {target!r}',
-                                'Latency:   {latency:.2f}ms'),
-                               target=target,
-                               latency=response.latency)
-            elif value is False:
-                self.log.error_trace(('Service IPC - Failed',
-                                      'Procedure: {target!r}',
-                                      'Latency:   {latency:.2f}ms'),
-                                     target=target,
-                                     latency=response.latency)
+            if value is False:
+                log_level = logging.ERROR
+                log_value = 'FAILED'
+                stack_info = True
+            else:
+                log_level = logging.DEBUG
+                log_value = value
+                stack_info = False
+            self.log.log(
+                level=log_level,
+                msg='Service IPC <{target}({payload})>:'
+                    ' {value} (in {time_ms:.2f}ms)',
+                target=target,
+                payload=payload,
+                value=log_value,
+                time_ms=response.latency,
+                stack_info=stack_info,
+                stacklevel=stacklevel,
+            )
         else:
             value = None
-            self.log.error_trace(('Service IPC - Timed out',
-                                  'Procedure: {target!r}',
-                                  'Timeout:   {timeout:.2f}s'),
-                                 target=target,
-                                 timeout=timeout)
+            self.log.error_trace(
+                'Service IPC <{target}({payload})>:'
+                ' TIMED OUT (in {time_s:.2f}s)',
+                target=target,
+                payload=payload,
+                time_s=timeout,
+                stacklevel=stacklevel,
+            )
         return value
 
     def is_plugin_folder(self, folder_name=None):

--- a/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
@@ -37,7 +37,6 @@ from ...constants import (
     VIDEO_ID,
 )
 from ...utils.datetime import datetime_to_since, utc_to_local
-from ...utils.redact import redact_ip_in_uri
 from ...utils.system_version import current_system_version
 
 
@@ -429,9 +428,9 @@ def set_info(list_item, item, properties, set_play_count=True, resume=True):
 
 def playback_item(context, media_item, show_fanart=None, **_kwargs):
     uri = media_item.get_uri()
-    logging.debug('Converting %s for playback: %r',
-                  media_item.__class__.__name__,
-                  redact_ip_in_uri(uri))
+    logging.debug('Converting {type} for playback: {uri!u}',
+                  type=media_item.__class__.__name__,
+                  uri=uri)
 
     params = context.get_params()
     settings = context.get_settings()

--- a/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
+++ b/resources/lib/youtube_plugin/kodion/items/xbmc/xbmc_items.py
@@ -484,7 +484,8 @@ def playback_item(context, media_item, show_fanart=None, **_kwargs):
             props['inputstream.adaptive.stream_selection_type'] = 'manual-osd'
         elif 'auto' in stream_select:
             props['inputstream.adaptive.stream_selection_type'] = 'adaptive'
-            props['inputstream.adaptive.chooser_resolution_max'] = 'auto'
+            if current_system_version.compatible(21):
+                props['inputstream.adaptive.chooser_resolution_max'] = 'auto'
 
         if current_system_version.compatible(19):
             props['inputstream'] = 'inputstream.adaptive'

--- a/resources/lib/youtube_plugin/kodion/json_store/json_store.py
+++ b/resources/lib/youtube_plugin/kodion/json_store/json_store.py
@@ -106,7 +106,7 @@ class JSONStore(object):
                 self._context.get_ui().set_property(
                     '-'.join((FILE_WRITE, filepath)),
                     to_unicode(_data),
-                    log_value='<redacted>',
+                    log_redact='REDACTED',
                 )
                 response = self._context.ipc_exec(
                     FILE_WRITE,
@@ -158,7 +158,7 @@ class JSONStore(object):
                 ) is not False:
                     data = self._context.get_ui().get_property(
                         '-'.join((FILE_READ, filepath)),
-                        log_value='<redacted>',
+                        log_redact='REDACTED',
                     )
                 else:
                     raise IOError

--- a/resources/lib/youtube_plugin/kodion/logging.py
+++ b/resources/lib/youtube_plugin/kodion/logging.py
@@ -20,7 +20,7 @@ from traceback import extract_stack, format_list
 
 from .compatibility import StringIO, string_type, to_str, xbmc
 from .constants import ADDON_ID
-from .utils.convert_format import to_unicode
+from .utils.convert_format import to_unicode, urls_in_text
 from .utils.redact import (
     parse_and_redact_uri,
     redact_auth_header,
@@ -74,24 +74,32 @@ class RecordFormatter(logging.Formatter):
 
     def format(self, record):
         record.message = to_unicode(record.getMessage())
+
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
+
         s = self.formatMessage(record)
+
+        if record.stack_info:
+            if not record.stack_text:
+                stack_text = self.formatStack(record.stack_info)
+                if getattr(record, '__redact_stack__', False):
+                    stack_text = urls_in_text(stack_text, parse_and_redact_uri)
+                record.stack_text = stack_text
+            if s[-1:] != '\n':
+                s += '\n\n'
+            s += record.stack_text
+
         if record.exc_info:
             if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
-        if record.exc_text:
-            if record.stack_info:
-                if s[-1:] != '\n':
-                    s += '\n\n'
-                s += self.formatStack(record.stack_info)
+                exc_text = self.formatException(record.exc_info)
+                if getattr(record, '__redact_exc__', False):
+                    exc_text = urls_in_text(exc_text, parse_and_redact_uri)
+                record.exc_text = exc_text
             if s[-1:] != '\n':
                 s += '\n\n'
             s += record.exc_text
-        elif record.stack_info:
-            if s[-1:] != '\n':
-                s += '\n\n'
-            s += self.formatStack(record.stack_info)
+
         return s
 
 
@@ -308,8 +316,7 @@ class Handler(logging.Handler):
 
 class LogRecord(logging.LogRecord):
     def __init__(self, name, level, pathname, lineno, msg, args, exc_info,
-                 func=None, **kwargs):
-        stack_info = kwargs.pop('sinfo', None)
+                 func=None, sinfo=None, extra=None, **kwargs):
         super(LogRecord, self).__init__(name,
                                         level,
                                         pathname,
@@ -319,7 +326,21 @@ class LogRecord(logging.LogRecord):
                                         exc_info,
                                         func=func,
                                         **kwargs)
-        self.stack_info = stack_info
+        self.message = None
+        self.asctime = None
+        self.stack_info = sinfo
+        self.stack_text = None
+        if extra is not None:
+            attrs = self.__dict__
+            duplicate_attrs = set(extra).intersection(attrs.keys())
+            if duplicate_attrs:
+                raise KeyError(
+                    "Attempt to overwrite LogRecord attributes: ('%s',)" % (
+                        "', '".join(duplicate_attrs)
+                    )
+                )
+            else:
+                attrs.update(extra)
 
     if not current_system_version.compatible(19):
         def getMessage(self):
@@ -423,21 +444,18 @@ class KodiLogger(logging.Logger):
 
     def makeRecord(self, name, level, fn, lno, msg, args, exc_info,
                    func=None, extra=None, sinfo=None):
-        rv = LogRecord(name,
-                       level,
-                       fn,
-                       lno,
-                       msg,
-                       args,
-                       exc_info,
-                       func=func,
-                       sinfo=sinfo)
-        if extra is not None:
-            for key in extra:
-                if (key in ["message", "asctime"]) or (key in rv.__dict__):
-                    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
-                rv.__dict__[key] = extra[key]
-        return rv
+        return LogRecord(
+            name,
+            level,
+            fn,
+            lno,
+            msg,
+            args,
+            exc_info,
+            func=func,
+            sinfo=sinfo,
+            extra=extra,
+        )
 
     def exception(self, msg, *args, **kwargs):
         if self.isEnabledFor(ERROR):

--- a/resources/lib/youtube_plugin/kodion/monitors/player_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/player_monitor.py
@@ -439,7 +439,7 @@ class PlayerMonitor(xbmc.Player):
 
         player_data = ui.pop_property(PLAYER_DATA,
                                       process=json.loads,
-                                      log_process=redact_params)
+                                      log_redact=True)
         if not player_data:
             return
         self.cleanup_threads()

--- a/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
@@ -213,7 +213,7 @@ class ServiceMonitor(xbmc.Monitor):
                                 self._context.get_ui().set_property(
                                     '-'.join((FILE_READ, filepath)),
                                     file.read(),
-                                    log_value='<redacted>',
+                                    log_redact='REDACTED',
                                 )
                                 response = True
                         except (IOError, OSError):
@@ -222,7 +222,7 @@ class ServiceMonitor(xbmc.Monitor):
                         with write_access:
                             content = self._context.get_ui().pop_property(
                                 '-'.join((FILE_WRITE, filepath)),
-                                log_value='<redacted>',
+                                log_redact='REDACTED',
                             )
                             response = None
                             if content:

--- a/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
+++ b/resources/lib/youtube_plugin/kodion/monitors/service_monitor.py
@@ -338,12 +338,15 @@ class ServiceMonitor(xbmc.Monitor):
         log_level = settings.log_level()
         if log_level:
             self.log.debugging = True
+            # Verbose
             if log_level & 2:
                 self.log.stack_info = True
                 self.log.verbose_logging = True
+            # Enabled or Auto on
             else:
                 self.log.stack_info = False
                 self.log.verbose_logging = False
+        # Disabled or Auto off
         else:
             self.log.debugging = False
             self.log.stack_info = False

--- a/resources/lib/youtube_plugin/kodion/network/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/network/http_server.py
@@ -13,14 +13,7 @@ import os
 import re
 import socket
 from collections import deque
-from errno import (
-    ECONNABORTED,
-    ECONNREFUSED,
-    ECONNRESET,
-    EPIPE,
-    EPROTOTYPE,
-    ESHUTDOWN,
-)
+from errno import errorcode
 from functools import partial
 from io import open
 from json import dumps as json_dumps, loads as json_loads
@@ -128,12 +121,17 @@ class RequestHandler(BaseHTTPRequestHandler, object):
     }
 
     SWALLOWED_ERRORS = {
-        ECONNABORTED,
-        ECONNREFUSED,
-        ECONNRESET,
-        EPIPE,
-        EPROTOTYPE,
-        ESHUTDOWN,
+        'ECONNABORTED',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'EPIPE',
+        'EPROTOTYPE',
+        'ESHUTDOWN',
+        'WSAECONNABORTED',
+        'WSAECONNREFUSED',
+        'WSAECONNRESET',
+        'WSAEPROTOTYPE',
+        'WSAESHUTDOWN',
     }
 
     def __init__(self, request, client_address, server):
@@ -176,11 +174,23 @@ class RequestHandler(BaseHTTPRequestHandler, object):
         try:
             super(RequestHandler, self).handle_one_request()
             return
-        except (HTTPError, OSError) as exc:
+        except Exception as exc:
             self.close_connection = True
             self.log.exception('Request failed')
-            if (isinstance(exc, HTTPError)
-                    or getattr(exc, 'errno', None) in self.SWALLOWED_ERRORS):
+            if isinstance(exc, HTTPError):
+                return
+            error = getattr(exc, 'errno', None)
+            if error and errorcode.get(error) in self.SWALLOWED_ERRORS:
+                return
+            raise exc
+
+    def finish(self):
+        try:
+            super(RequestHandler, self).finish()
+        except Exception as exc:
+            self.log.exception('File object failed to close cleanly')
+            error = getattr(exc, 'errno', None)
+            if error and errorcode.get(error) in self.SWALLOWED_ERRORS:
                 return
             raise exc
 

--- a/resources/lib/youtube_plugin/kodion/network/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/network/http_server.py
@@ -217,20 +217,22 @@ class RequestHandler(BaseHTTPRequestHandler, object):
         client_ip = self.client_address[0]
         ip_allowed, is_local, is_whitelisted = self.ip_address_status(client_ip)
 
-        parts, params, log_uri, log_params = parse_and_redact_uri(self.path)
+        uri = self.path
+        parts, params, log_uri, log_params, log_path = parse_and_redact_uri(uri)
         path = {
-            'full': self.path,
+            'uri': uri,
             'path': parts.path,
             'query': parts.query,
             'params': params,
-            'log_params': log_params,
             'log_uri': log_uri,
+            'log_path': log_path,
+            'log_params': log_params,
         }
 
         if not path['path'].startswith(PATHS.PING) and self.log.verbose_logging:
             self.log.debug(('{status}',
                             'Method:      {method!r}',
-                            'Path:        {path[path]!r}',
+                            'Path:        {path[log_path]!r}',
                             'Params:      {path[log_params]!r}',
                             'Address:     {client_ip!r}',
                             'Whitelisted: {is_whitelisted}',

--- a/resources/lib/youtube_plugin/kodion/network/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/network/http_server.py
@@ -458,11 +458,11 @@ class RequestHandler(BaseHTTPRequestHandler, object):
                         timestamp = ' (~%.2fs)' % (
                                 float(duration)
                                 *
-                                next(map(int, byte_range[6:].split('-')))
+                                int(byte_range[6:].split('-')[0])
                                 /
                                 int(clen)
                         )
-                    except (IndexError, StopIteration, ValueError):
+                    except ValueError:
                         timestamp = ''
             else:
                 timestamp = ''

--- a/resources/lib/youtube_plugin/kodion/network/requests.py
+++ b/resources/lib/youtube_plugin/kodion/network/requests.py
@@ -461,6 +461,7 @@ class BaseRequestsClass(object):
                                response_reason=response_reason,
                                response_text=response_text,
                                stacklevel=stacklevel,
+                               extra={'__redact_exc__': True},
                                **kwargs)
 
             if raise_exc:

--- a/resources/lib/youtube_plugin/kodion/network/requests.py
+++ b/resources/lib/youtube_plugin/kodion/network/requests.py
@@ -328,17 +328,19 @@ class BaseRequestsClass(object):
                 cookies=cookies,
                 hooks=hooks,
             ))
+        elif prepared_request:
+            method = prepared_request.method
+            url = prepared_request.url
+            headers = prepared_request.headers
 
         if stream:
             cache = False
         if cache is not False:
             if prepared_request:
-                method = prepared_request.method
                 if cache is True or method in self.METHODS_TO_CACHE:
-                    headers = prepared_request.headers
                     request_id = generate_hash(
                         method,
-                        prepared_request.url,
+                        url,
                         headers,
                         prepared_request.body,
                     )

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -19,7 +19,6 @@ from ...constants import (
     CONTAINER_FOCUS,
     CONTAINER_ID,
     CONTAINER_POSITION,
-    FOLDER_URI,
     FORCE_PLAY_PARAMS,
     PATHS,
     PLAYBACK_FAILED,
@@ -390,9 +389,7 @@ class XbmcPlugin(AbstractPlugin):
                         },
                     )
                 else:
-                    if context.is_plugin_path(
-                            ui.get_container_info(FOLDER_URI, container_id=None)
-                    ):
+                    if context.is_plugin_folder():
                         _, _post_run_action = self.uri_action(
                             context,
                             context.get_parent_uri(params={

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -467,8 +467,11 @@ class XbmcPlugin(AbstractPlugin):
                     action, action_kwargs = action
                 else:
                     action_kwargs = None
-                logging.debug('Executing queued post-run action: {action}',
+                logging.debug(('Executing queued post-run action',
+                               'Action:    {action}',
+                               'Arguments: {action_kwargs!p}'),
                               action=action,
+                              action_kwargs=action_kwargs,
                               stacklevel=2)
                 if callable(action):
                     if action_kwargs:

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -499,7 +499,7 @@ class XbmcPlugin(AbstractPlugin):
             result = True
 
         elif uri.startswith('PlayMedia('):
-            log_action = 'Redirect for playback queued'
+            log_action = 'PlayMedia queued'
             log_uri = uri[len('PlayMedia('):-1].split(',')
             log_uri[0] = parse_and_redact_uri(
                 log_uri[0],
@@ -566,20 +566,32 @@ class XbmcPlugin(AbstractPlugin):
             action = uri
             result = False
 
-        elif context.is_plugin_path(uri, PATHS.PLAY):
+        elif context.is_plugin_path(uri):
             parts, params, log_uri, _, _ = parse_and_redact_uri(uri)
-            if params.get(ACTION, [None])[0] == 'list':
+            path = parts.path.rstrip('/')
+
+            if path != PATHS.PLAY:
                 log_action = 'Redirect queued'
                 action = context.create_uri(
-                    (PATHS.ROUTE, parts.path.rstrip('/')),
+                    (PATHS.ROUTE, path or PATHS.HOME),
                     params,
                     run=True,
                 )
                 result = False
+
+            elif params.get(ACTION, [None])[0] == 'list':
+                log_action = 'Redirect for listing queued'
+                action = context.create_uri(
+                    (PATHS.ROUTE, path),
+                    params,
+                    run=True,
+                )
+                result = False
+
             else:
                 log_action = 'Redirect for playback queued'
                 action = context.create_uri(
-                    (parts.path.rstrip('/'),),
+                    path,
                     params,
                     play=(xbmc.PLAYLIST_MUSIC
                           if (context.get_ui().get_property(PLAY_FORCE_AUDIO)
@@ -587,16 +599,6 @@ class XbmcPlugin(AbstractPlugin):
                           xbmc.PLAYLIST_VIDEO),
                 )
                 result = True
-
-        elif context.is_plugin_path(uri):
-            log_action = 'Redirect queued'
-            parts, params, log_uri, _, _ = parse_and_redact_uri(uri)
-            action = context.create_uri(
-                (PATHS.ROUTE, parts.path.rstrip('/') or PATHS.HOME),
-                params,
-                run=True,
-            )
-            result = False
 
         else:
             action = None

--- a/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
+++ b/resources/lib/youtube_plugin/kodion/plugin/xbmc/xbmc_plugin.py
@@ -564,7 +564,7 @@ class XbmcPlugin(AbstractPlugin):
             result = False
 
         elif context.is_plugin_path(uri, PATHS.PLAY):
-            parts, params, log_uri, _ = parse_and_redact_uri(uri)
+            parts, params, log_uri, _, _ = parse_and_redact_uri(uri)
             if params.get(ACTION, [None])[0] == 'list':
                 log_action = 'Redirect queued'
                 action = context.create_uri(
@@ -587,7 +587,7 @@ class XbmcPlugin(AbstractPlugin):
 
         elif context.is_plugin_path(uri):
             log_action = 'Redirect queued'
-            parts, params, log_uri, _ = parse_and_redact_uri(uri)
+            parts, params, log_uri, _, _ = parse_and_redact_uri(uri)
             action = context.create_uri(
                 (PATHS.ROUTE, parts.path.rstrip('/') or PATHS.HOME),
                 params,

--- a/resources/lib/youtube_plugin/kodion/plugin_runner.py
+++ b/resources/lib/youtube_plugin/kodion/plugin_runner.py
@@ -55,13 +55,16 @@ def run(context=_context,
     log_level = settings.log_level()
     if log_level:
         log.debugging = True
+        # Verbose
         if log_level & 2:
             log.stack_info = True
             log.verbose_logging = True
+        # Enabled or Auto on
         else:
             log.stack_info = False
             log.verbose_logging = False
         profiler.enable(flush=True)
+    # Disabled or Auto off
     else:
         log.debugging = False
         log.stack_info = False

--- a/resources/lib/youtube_plugin/kodion/script_actions.py
+++ b/resources/lib/youtube_plugin/kodion/script_actions.py
@@ -481,12 +481,15 @@ def run(argv):
         log_level = context.get_settings().log_level()
         if log_level:
             log.debugging = True
+            # Verbose
             if log_level & 2:
                 log.stack_info = True
                 log.verbose_logging = True
+            # Enabled or Auto on
             else:
                 log.stack_info = False
                 log.verbose_logging = False
+        # Disabled or Auto off
         else:
             log.debugging = False
             log.stack_info = False

--- a/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
+++ b/resources/lib/youtube_plugin/kodion/settings/abstract_settings.py
@@ -825,8 +825,12 @@ class AbstractSettings(object):
     def log_level(self, value=None):
         if value is not None:
             return self.set_int(SETTINGS.LOG_LEVEL, value)
-        return (self.get_int(SETTINGS.LOG_LEVEL, 0)
-                or get_kodi_setting_bool('debug.showloginfo'))
+        log_level = self.get_int(SETTINGS.LOG_LEVEL, 0)
+        if not log_level:
+            return get_kodi_setting_bool('debug.showloginfo')
+        if log_level & 4:
+            log_level = 0
+        return log_level
 
     def exec_limit(self, value=None):
         if value is not None:

--- a/resources/lib/youtube_plugin/kodion/ui/abstract_context_ui.py
+++ b/resources/lib/youtube_plugin/kodion/ui/abstract_context_ui.py
@@ -134,8 +134,7 @@ class AbstractContextUI(object):
                      value='true',
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False):
         raise NotImplementedError()
 
@@ -144,8 +143,7 @@ class AbstractContextUI(object):
                      property_id,
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False,
                      as_bool=False,
                      default=False):
@@ -156,8 +154,7 @@ class AbstractContextUI(object):
                      property_id,
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False,
                      as_bool=False,
                      default=False):

--- a/resources/lib/youtube_plugin/kodion/ui/xbmc/xbmc_context_ui.py
+++ b/resources/lib/youtube_plugin/kodion/ui/xbmc/xbmc_context_ui.py
@@ -532,14 +532,15 @@ class XbmcContextUI(AbstractContextUI):
                      value='true',
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False):
-        if log_value is None:
+        if log_redact is True:
+            log_msg = 'Set property {property_id!r}: {value!p}'
             log_value = value
-        if log_process:
-            log_value = log_process(log_value)
-        cls.log.debug_trace('Set property {property_id!r}: {value!r}',
+        else:
+            log_msg = 'Set property {property_id!r}: {value!r}'
+            log_value = log_redact or value
+        cls.log.debug_trace(log_msg,
                             property_id=property_id,
                             value=log_value,
                             stacklevel=stacklevel)
@@ -554,18 +555,19 @@ class XbmcContextUI(AbstractContextUI):
                      property_id,
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False,
                      as_bool=False,
                      default=False):
         _property_id = property_id if raw else '-'.join((ADDON_ID, property_id))
         value = xbmcgui.Window(10000).getProperty(_property_id)
-        if log_value is None:
+        if log_redact is True:
+            log_msg = 'Get property {property_id!r}: {value!p}'
             log_value = value
-        if log_process:
-            log_value = log_process(log_value)
-        cls.log.debug_trace('Get property {property_id!r}: {value!r}',
+        else:
+            log_msg = 'Get property {property_id!r}: {value!r}'
+            log_value = log_redact or value
+        cls.log.debug_trace(log_msg,
                             property_id=property_id,
                             value=log_value,
                             stacklevel=stacklevel)
@@ -578,8 +580,7 @@ class XbmcContextUI(AbstractContextUI):
                      property_id,
                      stacklevel=2,
                      process=None,
-                     log_value=None,
-                     log_process=None,
+                     log_redact=False,
                      raw=False,
                      as_bool=False,
                      default=False):
@@ -590,11 +591,13 @@ class XbmcContextUI(AbstractContextUI):
             window.clearProperty(_property_id)
             if process:
                 value = process(value)
-        if log_value is None:
+        if log_redact is True:
+            log_msg = 'Pop property {property_id!r}: {value!p}'
             log_value = value
-        if log_value and log_process:
-            log_value = log_process(log_value)
-        cls.log.debug_trace('Pop property {property_id!r}: {value!r}',
+        else:
+            log_msg = 'Pop property {property_id!r}: {value!r}'
+            log_value = log_redact or value
+        cls.log.debug_trace(log_msg,
                             property_id=property_id,
                             value=log_value,
                             stacklevel=stacklevel)

--- a/resources/lib/youtube_plugin/kodion/utils/convert_format.py
+++ b/resources/lib/youtube_plugin/kodion/utils/convert_format.py
@@ -17,6 +17,15 @@ from re import DOTALL, compile as re_compile
 from ..compatibility import byte_string_type
 
 
+__RE_URL = re_compile(r'(https?://\S+)')
+
+
+def urls_in_text(text, process=None, count=0):
+    if process:
+        return __RE_URL.sub(process, text, count=count)
+    return __RE_URL.findall(text)
+
+
 def to_unicode(text):
     if isinstance(text, byte_string_type):
         try:

--- a/resources/lib/youtube_plugin/kodion/utils/redact.py
+++ b/resources/lib/youtube_plugin/kodion/utils/redact.py
@@ -73,6 +73,12 @@ def redact_params(params,
                           'refresh_token',
                           'token',
                   )),
+                  _path_params=frozenset((
+                          'conn',
+                  )),
+                  _query_params=frozenset((
+                          'stream',
+                  )),
                   _url_params=frozenset((
                           'playing_file',
                           'url',
@@ -122,6 +128,19 @@ def redact_params(params,
             log_value = [
                 'REDACTED'
                 for _ in value
+            ]
+        elif param in _path_params:
+            log_value = [
+                redact_ip(val)
+                for val in value
+            ]
+        elif param in _query_params:
+            log_value = [
+                parse_and_redact_uri(
+                    val if val.startswith('?') else '?' + val,
+                    redact_only=True,
+                )
+                for val in value
             ]
         elif param in _url_params:
             log_value = [

--- a/resources/lib/youtube_plugin/kodion/utils/redact.py
+++ b/resources/lib/youtube_plugin/kodion/utils/redact.py
@@ -13,15 +13,19 @@ from __future__ import absolute_import, division, unicode_literals
 from base64 import urlsafe_b64decode
 from re import compile as re_compile
 
-from ..compatibility import parse_qs, urlencode, urlsplit, urlunsplit
+from ..compatibility import (
+    parse_qs,
+    string_type,
+    urlencode,
+    urlsplit,
+    urlunsplit,
+)
 from ..constants.const_settings import API_ID, API_KEY, API_SECRET, LOCATION
 
 
-def redact_ip_in_uri(
-        url,
-        _re=re_compile(r'([?&/]|%3F|%26|%2F)ip([=/]|%3D|%2F)[^?&/%]+'),
-):
-    return _re.sub(r'\g<1>ip\g<2><redacted>', url)
+def redact_ip(url,
+              _re=re_compile(r'([?&/]|%3F|%26|%2F)ip([=/]|%3D|%2F)[^?&/%]+')):
+    return _re.sub(r'\g<1>ip\g<2>REDACTED', url)
 
 
 def redact_auth_header(headers,
@@ -32,120 +36,147 @@ def redact_auth_header(headers,
     if isinstance(headers, dict):
         log_headers = headers.copy()
         if 'Authorization' in log_headers:
-            log_headers['Authorization'] = '<redacted>'
+            log_headers['Authorization'] = 'REDACTED'
         return log_headers
-    return _re.sub(r'"Authorization": "<redacted>"', headers)
+    return _re.sub(r'"Authorization": "REDACTED"', headers)
 
 
 def redact_license_info(license_info):
     license_info = license_info.copy()
     for detail in ('url', 'token'):
         if detail in license_info:
-            license_info[detail] = '<redacted>'
+            license_info[detail] = 'REDACTED'
     return license_info
 
 
-def redact_params(params, _seq_types=(list, tuple)):
+def redact_params(params,
+                  _seq_types=(list, tuple),
+                  _partially_redacted_secret_params=frozenset((
+                          'key',
+                          'api_key',
+                          API_KEY,
+                          'api_secret',
+                          API_SECRET,
+                          'client_secret',
+                          'secret',
+                  )),
+                  _partially_redacted_id_params=frozenset((
+                          'api_id',
+                          API_ID,
+                          'client_id',
+                  )),
+                  _fully_redacted_params=frozenset((
+                          'access_token',
+                          'code',
+                          'ip',
+                          'playback_stats',
+                          'refresh_token',
+                          'token',
+                  )),
+                  _url_params=frozenset((
+                          'playing_file',
+                          'url',
+                  )),
+                  _location_params=frozenset((
+                          'location',
+                          LOCATION,
+                  )),
+                  _header_params=frozenset((
+                          'headers',
+                          '__headers',
+                  ))):
     if not params:
         return params
 
     log_params = params.copy()
     for param, value in params.items():
         if not value:
-            log_value = value
-        elif isinstance(value, dict):
-            log_value = redact_params(value)
-        elif param in {'key',
-                       'api_key',
-                       API_KEY,
-                       'api_secret',
-                       API_SECRET,
-                       'client_secret',
-                       'secret'}:
-            log_value = (
-                ['...'.join((val[:3], val[-3:]))
-                 if len(val) > 9 else
-                 '...'
-                 for val in value]
-                if isinstance(value, _seq_types) else
-                '...'.join((value[:3], value[-3:]))
-                if len(value) > 9 else
+            continue
+
+        if isinstance(value, dict):
+            log_params[param] = redact_params(value)
+            continue
+
+        if isinstance(value, _seq_types):
+            doseq = True
+        else:
+            doseq = False
+            value = (value,)
+
+        if param in _partially_redacted_secret_params:
+            log_value = [
+                '...'.join((val[:3], val[-3:]))
+                if len(val) > 9 else
                 '...'
-            )
-        elif param in {'api_id', API_ID, 'client_id'}:
-            if isinstance(value, _seq_types):
-                log_value = []
-                for val in value:
-                    val = val.replace('.apps.googleusercontent.com', '')
-                    if len(val) > 11:
-                        log_value.append('...'.join((val[:3], val[-5:])))
-                    else:
-                        log_value.append('...')
-            else:
-                log_value = value.replace('.apps.googleusercontent.com', '')
-                if len(log_value) > 11:
-                    log_value = '...'.join((log_value[:3], log_value[-5:]))
+                for val in value
+            ]
+        elif param in _partially_redacted_id_params:
+            log_value = []
+            for val in value:
+                val = val.replace('.apps.googleusercontent.com', '')
+                if len(val) > 11:
+                    log_value.append('...'.join((val[:3], val[-5:])))
                 else:
-                    log_value = '...'
-        elif param in {'access_token',
-                       'code',
-                       'ip',
-                       'playback_stats',
-                       'refresh_token',
-                       'token'}:
-            log_value = (
-                ['<redacted>' for _ in value]
-                if isinstance(value, _seq_types) else
-                '<redacted>'
-            )
-        elif param in {'url', 'playing_file'}:
-            log_value = (
-                [redact_ip_in_uri(val) for val in value]
-                if isinstance(value, _seq_types) else
-                redact_ip_in_uri(value)
-            )
-        elif param in {'location', LOCATION}:
-            log_value = (
-                ['xx.xxxx,xx.xxxx' for _ in value]
-                if isinstance(value, _seq_types) else
+                    log_value.append('...')
+        elif param in _fully_redacted_params:
+            log_value = [
+                'REDACTED'
+                for _ in value
+            ]
+        elif param in _url_params:
+            log_value = [
+                parse_and_redact_uri(val, redact_only=True)
+                for val in value
+            ]
+        elif param in _location_params:
+            log_value = [
                 'xx.xxxx,xx.xxxx'
-            )
-        elif param in {'headers', '__headers'}:
-            log_value = (
-                [redact_auth_header(val) for val in value]
-                if isinstance(value, _seq_types) else
-                redact_auth_header(value)
-            )
+                for _ in value
+            ]
+        elif param in _header_params:
+            log_value = [
+                redact_auth_header(val)
+                for val in value
+            ]
         elif param == 'license_info':
-            log_value = (
-                [redact_license_info(val) for val in value]
-                if isinstance(value, _seq_types) else
-                redact_license_info(value)
-            )
+            log_value = [
+                redact_license_info(val)
+                for val in value
+            ]
         else:
             continue
-        log_params[param] = log_value
+        log_params[param] = log_value if doseq else log_value[0]
     return log_params
 
 
 def parse_and_redact_uri(uri, redact_only=False):
+    if not isinstance(uri, string_type):
+        uri = getattr(uri, 'group', str)()
+        redact_only = True
+
     parts = urlsplit(uri or '')
+
+    log_path = redact_ip(parts.path)
+
     if parts.query:
         params = parse_qs(parts.query, keep_blank_values=True)
         headers = params.get('__headers', [None])[0]
         if headers:
             params['__headers'] = [urlsafe_b64decode(headers).decode('utf-8')]
         log_params = redact_params(params)
-        log_uri = urlunsplit((
-            parts.scheme,
-            parts.netloc,
-            parts.path,
-            urlencode(log_params, doseq=True),
-            '',
-        ))
+        log_query = urlencode(log_params, doseq=True)
     else:
         params = log_params = None
-        log_uri = uri
+        log_query = ''
+
+    log_uri = urlunsplit((
+        parts.scheme,
+        parts.netloc,
+        log_path,
+        log_query,
+        '',
+    ))
+
     if redact_only:
         return log_uri
-    return parts, params, log_uri, log_params
+    return parts, params, log_uri, log_params, log_path

--- a/resources/lib/youtube_plugin/youtube/client/player_client.py
+++ b/resources/lib/youtube_plugin/youtube/client/player_client.py
@@ -894,18 +894,20 @@ class YouTubePlayerClient(YouTubeDataClient):
 
         if not json_data or 'error' not in json_data:
             info = (
-                'video_id: {video_id!r}',
-                'Client:   {client_name!r}',
-                'Auth:     {has_auth!r}',
+                'video_id:      {video_id!r}',
+                'Client:        {client_name!r}',
+                'Auth:          {has_auth!r}',
+                'Valid visitor: {has_visitor_data}',
             )
             return None, info, None, data, exception
 
         info = (
-            'Reason:   {error_reason}',
-            'Message:  {error_message}',
-            'video_id: {video_id!r}',
-            'Client:   {client_name!r}',
-            'Auth:     {has_auth!r}',
+            'Reason:        {error_reason!r}',
+            'Message:       {error_message!r}',
+            'video_id:      {video_id!r}',
+            'Client:        {client_name!r}',
+            'Auth:          {has_auth!r}',
+            'Valid visitor: {has_visitor_data}',
         )
         details = json_data['error']
         details = {
@@ -1092,7 +1094,8 @@ class YouTubePlayerClient(YouTubeDataClient):
             error_hook=self._player_error_hook,
             video_id=self.video_id,
             client_name=client_name,
-            has_auth=False,
+            has_auth=client.get('_has_auth'),
+            has_visitor_data=bool(client.get('_visitor_data')),
             cache=False,
         )
         if not result:
@@ -1191,7 +1194,8 @@ class YouTubePlayerClient(YouTubeDataClient):
         itags = ('9995', '9996') if is_live else ('9993', '9994')
 
         for client_name, response in responses.items():
-            headers = response['client']['headers']
+            client = response['client']
+            headers = client['headers']
             url = self._process_url_params(
                 response['hls_manifest'],
                 headers=headers,
@@ -1207,7 +1211,8 @@ class YouTubePlayerClient(YouTubeDataClient):
                 error_hook=self._player_error_hook,
                 video_id=self.video_id,
                 client_name=client_name,
-                has_auth=False,
+                has_auth=client.get('_has_auth'),
+                has_visitor_data=bool(client.get('_visitor_data')),
                 cache=False,
             )
             if not result:
@@ -1558,6 +1563,7 @@ class YouTubePlayerClient(YouTubeDataClient):
                 video_id=video_id,
                 client_name=client_name,
                 has_auth=client.get('_has_auth'),
+                has_visitor_data=bool(client.get('_visitor_data')),
                 cache=False,
                 **client
             )
@@ -1653,6 +1659,7 @@ class YouTubePlayerClient(YouTubeDataClient):
 
         auth_client = None
         visitor_data = self._visitor_data[visitor_data_key]
+        has_visitor_data = bool(visitor_data)
         video_details = {}
         microformat = {}
         responses = {}
@@ -1730,6 +1737,7 @@ class YouTubePlayerClient(YouTubeDataClient):
                         video_id=video_id,
                         client_name=_client_name,
                         has_auth=_has_auth,
+                        has_visitor_data=has_visitor_data,
                         cache=False,
                         pass_data=True,
                         raise_exc=False,
@@ -1762,6 +1770,8 @@ class YouTubePlayerClient(YouTubeDataClient):
                         if visitor_data:
                             client_data['_visitor_data'] = visitor_data
                             self._visitor_data[visitor_data_key] = visitor_data
+                            has_visitor_data = True
+
                     _video_details = _result.get('videoDetails', {})
                     _microformat = (_result
                                     .get('microformat', {})
@@ -1792,16 +1802,18 @@ class YouTubePlayerClient(YouTubeDataClient):
                         break
                     elif not _playability or _status in bad_statuses:
                         self.log.warning(('Failed to retrieve stream info',
-                                          'Status:   {status}',
-                                          'Reason:   {reason}',
-                                          'video_id: {video_id!r}',
-                                          'Client:   {client!r}',
-                                          'Auth:     {has_auth!r}'),
+                                          'Status:        {status!r}',
+                                          'Reason:        {reason!r}',
+                                          'video_id:      {video_id!r}',
+                                          'Client:        {client!r}',
+                                          'Auth:          {has_auth!r}',
+                                          'Valid visitor: {has_visitor_data}'),
                                          status=_status,
                                          reason=_reason or 'UNKNOWN',
                                          video_id=video_id,
                                          client=_client_name,
-                                         has_auth=_has_auth)
+                                         has_auth=_has_auth,
+                                         has_visitor_data=has_visitor_data)
 
                         fail_reason = _reason.lower()
 
@@ -1849,12 +1861,14 @@ class YouTubePlayerClient(YouTubeDataClient):
 
             if _status == 'OK':
                 self.log.debug(('Retrieved stream info:',
-                                'video_id: {video_id!r}',
-                                'Client:   {client!r}',
-                                'Auth:     {has_auth!r}'),
+                                'video_id:      {video_id!r}',
+                                'Client:        {client!r}',
+                                'Auth:          {has_auth!r}',
+                                'Valid visitor: {has_visitor_data}'),
                                video_id=video_id,
                                client=_client_name,
-                               has_auth=_has_auth)
+                               has_auth=_has_auth,
+                               has_visitor_data=has_visitor_data)
 
                 video_details = merge_dicts(
                     _video_details,

--- a/resources/lib/youtube_plugin/youtube/client/player_client.py
+++ b/resources/lib/youtube_plugin/youtube/client/player_client.py
@@ -39,7 +39,6 @@ from ...kodion.network import get_connect_address
 from ...kodion.utils.datetime import fromtimestamp
 from ...kodion.utils.file_system import make_dirs
 from ...kodion.utils.methods import merge_dicts
-from ...kodion.utils.redact import redact_ip_in_uri
 
 
 class YouTubePlayerClient(YouTubeDataClient):
@@ -1232,21 +1231,21 @@ class YouTubePlayerClient(YouTubeDataClient):
                 if itag in stream_list:
                     continue
 
+                url = match.group('url')
                 yt_format = self._get_stream_format(
                     itag=itag,
                     max_height=selected_height,
                     title='',
-                    url=match.group('url'),
+                    url=url,
                     meta=meta_info,
                     headers=headers,
                     playback_stats=playback_stats,
                 )
                 if yt_format is None:
-                    stream_info = redact_ip_in_uri(match.group(1))
                     self.log.debug(('Unknown itag - {itag}',
-                                    '{stream}'),
+                                    '{url!u}'),
                                    itag=itag,
-                                   stream=stream_info)
+                                   url=url)
                 if (not yt_format
                         or (yt_format.get('hls/video')
                             and not yt_format.get('hls/audio'))):
@@ -1333,14 +1332,8 @@ class YouTubePlayerClient(YouTubeDataClient):
                     playback_stats=playback_stats,
                 )
                 if yt_format is None:
-                    if url:
-                        stream_map['url'] = redact_ip_in_uri(url)
-                    if conn:
-                        stream_map['conn'] = redact_ip_in_uri(conn)
-                    if stream:
-                        stream_map['stream'] = redact_ip_in_uri(stream)
                     self.log.debug(('Unknown itag - {itag}',
-                                    '{stream}'),
+                                    '{stream!p}'),
                                    itag=itag,
                                    stream=stream_map)
                 if (not yt_format

--- a/resources/lib/youtube_plugin/youtube/client/player_client.py
+++ b/resources/lib/youtube_plugin/youtube/client/player_client.py
@@ -1425,7 +1425,7 @@ class YouTubePlayerClient(YouTubeDataClient):
         params = parse_qs(parts.query)
         new_params = {}
 
-        if 'n' not in params:
+        if 'n' not in params and '/n/' not in parts.path:
             pass
         elif not self._calculate_n:
             self.log.debug('Decoding of nsig value disabled')

--- a/resources/lib/youtube_plugin/youtube/helper/utils.py
+++ b/resources/lib/youtube_plugin/youtube/helper/utils.py
@@ -66,12 +66,6 @@ __RE_SEASON_EPISODE = re_compile(
     r'\b(?:Season\s*|S)(\d+)|(?:\b(?:Part|Ep.|Episode)\s*|#|E)(\d+)'
 )
 
-__RE_URL = re_compile(r'(https?://\S+)')
-
-
-def extract_urls(text):
-    return __RE_URL.findall(text)
-
 
 def get_thumb_timestamp(minutes=15):
     seconds = minutes * 60

--- a/resources/lib/youtube_plugin/youtube/helper/yt_login.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_login.py
@@ -132,13 +132,8 @@ def _do_login(provider, context, client=None, **kwargs):
                     if not json_data:
                         break
 
-                    log_data = json_data.copy()
-                    if 'access_token' in log_data:
-                        log_data['access_token'] = '<redacted>'
-                    if 'refresh_token' in log_data:
-                        log_data['refresh_token'] = '<redacted>'
-                    logging.debug('Requesting access token: {data!r}',
-                                  data=log_data)
+                    logging.debug('Requesting access token: {data!p}',
+                                  data=json_data)
 
                     if 'error' not in json_data:
                         access_token = json_data.get('access_token', '')

--- a/resources/lib/youtube_plugin/youtube/helper/yt_play.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_play.py
@@ -182,7 +182,7 @@ def _play_stream(provider, context):
     ui.set_property(PLAYER_DATA,
                     value=playback_data,
                     process=json.dumps,
-                    log_process=redact_params)
+                    log_redact=True)
     ui.set_property(TRAKT_PAUSE_FLAG, raw=True)
     context.send_notification(PLAYBACK_INIT, playback_data)
     return media_item

--- a/resources/lib/youtube_plugin/youtube/helper/yt_play.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_play.py
@@ -542,7 +542,7 @@ def process(provider, context, **_kwargs):
             # Action(Play) does not work in non-video windows
             if ((force_play_params or params.get(CONTEXT_MENU))
                     and not params.get(PLAY_STRM)
-                    and context.is_plugin_folder()):
+                    and context.is_plugin_folder(name=True)):
                 return UriItem('command://Action(Play)')
 
             return UriItem('command://{0}'.format(

--- a/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_setup_wizard.py
@@ -401,21 +401,23 @@ def process_refresh_settings(context, step, steps, **_kwargs):
 
 def process_migrate_watch_history(context, step, steps, **_kwargs):
     localize = context.localize
+    settings = context.get_settings()
     access_manager = context.get_access_manager()
     watch_history_id = access_manager.get_watch_history_id().upper()
 
     step += 1
-    if (watch_history_id != 'HL' and context.get_ui().on_yes_no_input(
-            '{youtube} - {setup_wizard} ({step}/{steps})'.format(
-                youtube=localize('youtube'),
-                setup_wizard=localize('setup_wizard'),
-                step=step,
-                steps=steps,
-            ),
-            localize('setup_wizard.prompt.migrate_watch_history'),
-    )):
+    if ((watch_history_id != 'HL' or not settings.use_remote_history())
+            and context.get_ui().on_yes_no_input(
+                '{youtube} - {setup_wizard} ({step}/{steps})'.format(
+                    youtube=localize('youtube'),
+                    setup_wizard=localize('setup_wizard'),
+                    step=step,
+                    steps=steps,
+                ),
+                localize('setup_wizard.prompt.migrate_watch_history'),
+            )):
         access_manager.set_watch_history_id('HL')
-        context.get_settings().use_remote_history(True)
+        settings.use_remote_history(True)
     return step
 
 

--- a/resources/lib/youtube_plugin/youtube/helper/yt_specials.py
+++ b/resources/lib/youtube_plugin/youtube/helper/yt_specials.py
@@ -30,7 +30,7 @@ from ...kodion.constants import (
     VIDEO_ID,
 )
 from ...kodion.items import DirectoryItem, UriItem
-from ...kodion.utils.convert_format import strip_html_from_text
+from ...kodion.utils.convert_format import strip_html_from_text, urls_in_text
 
 
 def _process_related_videos(provider, context, client):
@@ -291,7 +291,7 @@ def _process_description_links(provider, context):
 
             function_cache = context.get_function_cache()
             urls = function_cache.run(
-                utils.extract_urls,
+                urls_in_text,
                 function_cache.ONE_DAY,
                 _refresh=context.refresh_requested(),
                 text=description,

--- a/resources/lib/youtube_plugin/youtube/provider.py
+++ b/resources/lib/youtube_plugin/youtube/provider.py
@@ -2071,8 +2071,8 @@ class Provider(AbstractProvider):
             return (
                 True,
                 {
-                    provider.FORCE_REFRESH: context.get_path().startswith(
-                        PATHS.BOOKMARKS
+                    provider.FORCE_REFRESH: context.is_plugin_folder(
+                        PATHS.BOOKMARKS,
                     ),
                 },
             )

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1262,10 +1262,10 @@
                     <default>0</default>
                     <constraints>
                         <options>
-                            <option label="13106">0</option> <!-- Disabled -->
-                            <option label="305">1</option>   <!-- Enabled -->
-                            <option label="30621">2</option> <!-- Verbose -->
-                            <!-- <option label="666">4</option> -->   <!-- Component specific -->
+                            <option label="13106">4</option> <!-- Disabled (addon logging output disabled) -->
+                            <option label="16316">0</option> <!-- Auto (addon logging output enabled if Kodi debug logging enabled) -->
+                            <option label="13108">1</option> <!-- Always enabled (addon logging output enabled) -->
+                            <option label="30621">2</option> <!-- Verbose (additional addon logging output enabled)  -->
                         </options>
                     </constraints>
                     <control format="string" type="spinner"/>


### PR DESCRIPTION
### Fixed
- Skip unplayable live manifests #1377
- Handle inconsistent error codes and names used in Python 2 #1412
- Simplify byte range to timestamp conversion for compatibility with Python 2 #1412
- Fix unnecessarily reloading listing when adding items to Bookmarks

### Changed
- Rework addon debug log settings (Addon > Settings > Advanced > Debug > Enable debug logging) #1385
  - Allowable values:
    - Disabled (addon logging output disabled)
    - Auto (default, addon logging output enabled if Kodi debug logging enabled)
    - Always enabled (addon logging output enabled)
    - Verbose (additional addon logging output enabled)
- Various other improvement to addon logging

### New
- Update Setup Wizard to account for user possibly using mismatched watch history settings