### PR TITLE
v7.4.3

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.4.3+beta.3" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.4.3" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,26 @@
+## v7.4.3
+### Fixed
+- Limit chunk size when reading stream proxy response #1444
+- Fix regressions with accessing http urls
+- Improve handling of retries upon server error #1438
+- Improve identification of post-live streams #1420
+- Updates to resolve inconsistent Python2 string encoding/decoding
+- Ensure parameters to Kodi builtin functions are parsed as string literals
+- Allow trailing slashes in url of html pages served by internal http server
+
+### Changed
+- Rename Subscriptions to Subscribed Channels #1435
+- Open confirmation dialog, with a link for further information, when sign in process fails
+- Update API config page html
+- Improve handling of API key settings changes
+- Detect and notify when API requests cannot be completed
+- Use consistent language for signing in/out
+
+### New
+- Add button in API settings to view address of API config page
+- Fallback to playing channel uploads if no live stream is available
+- Add fallback method to load playlists when v3 API request cannot be made
+
 ## v7.4.3+beta.3
 ### Fixed
 - Fix regressions with accessing http urls

--- a/resources/lib/youtube_plugin/kodion/network/http_server.py
+++ b/resources/lib/youtube_plugin/kodion/network/http_server.py
@@ -580,13 +580,15 @@ class RequestHandler(BaseHTTPRequestHandler, object):
                     if content:
                         wfile.write(content)
                     else:
-                        wfile.write(
-                            response.raw.read(
-                                amt=None,
+                        while 1:
+                            content = response.raw.read(
+                                amt=1048576,
                                 decode_content=False,
                                 cache_content=False,
                             )
-                        )
+                            if not content:
+                                break
+                            wfile.write(content)
                 break
 
         else:


### PR DESCRIPTION
### Fixed
- Limit chunk size when reading stream proxy response #1444
- Fix regressions with accessing http urls
- Improve handling of retries upon server error #1438
- Improve identification of post-live streams #1420
- Updates to resolve inconsistent Python2 string encoding/decoding
- Ensure parameters to Kodi builtin functions are parsed as string literals
- Allow trailing slashes in url of html pages served by internal http server

### Changed
- Rename Subscriptions to Subscribed Channels #1435
- Open confirmation dialog, with a link for further information, when sign in process fails
- Update API config page html
- Improve handling of API key settings changes
- Detect and notify when API requests cannot be completed
- Use consistent language for signing in/out

### New
- Add button in API settings to view address of API config page
- Fallback to playing channel uploads if no live stream is available
- Add fallback method to load playlists when v3 API request cannot be made