### PR TITLE
v7.4.4

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="7.4.4+beta.4" provider-name="anxdpanic, bromix, MoojMidge">
+<addon id="plugin.video.youtube" name="YouTube" version="7.4.4" provider-name="anxdpanic, bromix, MoojMidge">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
         <import addon="script.module.requests" version="2.27.1"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,20 @@
+## v7.4.4
+### Fixed
+- Fix not including FolderPath in current container details #1467
+- Fix current plugin item window properties sometimes not updating correctly
+- Fix not updating remote history upon consecutive playback events for certain video types
+- Fix using unimplemented change to localisation identifier when showing API config page address
+- Fix play uri parameters/properties not being able to be forced off
+- Limit retrying feeds that cannot be accessed #1425
+
+### Changed
+- Improve responsiveness of service loop upon plugin invocation
+- Log redacted visitorData details #1425
+- More aggressively utilise cached data for My Subscriptions feed failures #1425
+
+### New
+- Add option to play YouTube error notification video upon playback failure #1428
+
 ## v7.4.4+beta.4
 ### Fixed
 - Fix not including FolderPath in current container details #1467


### PR DESCRIPTION
### Fixed
- Fix not including FolderPath in current container details #1467
- Fix current plugin item window properties sometimes not updating correctly
- Fix not updating remote history upon consecutive playback events for certain video types
- Fix using unimplemented change to localisation identifier when showing API config page address
- Fix play uri parameters/properties not being able to be forced off
- Limit retrying feeds that cannot be accessed #1425

### Changed
- Improve responsiveness of service loop upon plugin invocation
- Log redacted visitorData details #1425
- More aggressively utilise cached data for My Subscriptions feed failures #1425

### New
- Add option to play YouTube error notification video upon playback failure #1428